### PR TITLE
[Creative][Calendar-DB] Conflict-free merge (CRDT風) for multi-device edits

### DIFF
--- a/crates/pomodoroom-core/src/events.rs
+++ b/crates/pomodoroom-core/src/events.rs
@@ -57,4 +57,24 @@ pub enum Event {
         checkpoint_id: String,
         at: DateTime<Utc>,
     },
+    /// Operation log entry for CRDT-style conflict-free merge
+    /// Each operation is causally ordered and can be merged deterministically
+    OperationLog {
+        operation_id: String,
+        operation_type: String,
+        data: serde_json::Value,
+        causal_metadata: CausalMetadata,
+        at: DateTime<Utc>,
+    },
+}
+
+/// Causal metadata for operation ordering and conflict detection
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CausalMetadata {
+    /// Lamport timestamp for causal ordering
+    pub lamport_ts: u64,
+    /// Device/node identifier that generated this operation
+    pub device_id: String,
+    /// Vector clock for precise causal ordering (optional)
+    pub vector_clock: Option<std::collections::HashMap<String, u64>>,
 }


### PR DESCRIPTION
## Summary
- Add OperationLog event with CausalMetadata (Lamport timestamp, device_id, vector_clock)
- Add operation_log table to database schema  
- Add methods: append_operation, get_operations_since, get_max_lamport_ts, merge_operations
- Implement Last-Writer-Wins merge based on Lamport timestamps
- Add comprehensive tests for operation log and merge functionality

Closes #288

## Test plan
- [x] cargo test -p pomodoroom-core (112 tests passed)
- [x] cargo test -p pomodoroom-cli (20 tests passed)
- [x] pnpm run check (52 tests passed)

## Test Evidence

### Unit Tests
- `append_and_retrieve_operation`: Verifies operation persistence and retrieval
- `get_max_lamport_ts`: Tests timestamp tracking
- `merge_operations_deduplicates`: Validates idempotent merge behavior
- `operations_since_timestamp`: Tests causal ordering queries

### Integration
All existing tests pass, confirming backward compatibility.

## Implementation details
This implementation adds CRDT-style operation logging for conflict-free
multi-device synchronization. The system can now:
1. Log each operation with causal metadata (Lamport timestamps, device IDs)
2. Query operations since a given timestamp for incremental sync
3. Merge remote operations deterministically using Last-Writer-Wins
4. Handle duplicate operations gracefully during merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)