### PR TITLE
feat(insights): Weekly retro自動生成（成果/失敗/改善）

### DIFF
--- a/src/utils/weeklyRetroGenerator.ts
+++ b/src/utils/weeklyRetroGenerator.ts
@@ -1,0 +1,315 @@
+/**
+ * Weekly Retro Generator
+ *
+ * Automatically generates weekly retrospective documents based on
+ * session data, analyzing achievements, failures, and improvements.
+ */
+
+import type { SessionData, StatsData } from "@/hooks/useStats";
+
+export interface WeeklyRetroData {
+	weekStart: string;
+	weekEnd: string;
+	sessions: SessionData[];
+	stats: StatsData;
+}
+
+export interface RetroSection {
+	title: string;
+	items: string[];
+}
+
+export interface WeeklyRetro {
+	title: string;
+	period: string;
+	summary: string;
+	achievements: RetroSection;
+	challenges: RetroSection;
+	improvements: RetroSection;
+	nextWeekGoals: RetroSection;
+	rawMarkdown: string;
+}
+
+/**
+ * Calculate project distribution from sessions
+ */
+function getProjectDistribution(
+	sessions: SessionData[],
+): Array<{ project: string; minutes: number; percentage: number }> {
+	const projectMinutes: Record<string, number> = {};
+	let totalMinutes = 0;
+
+	for (const session of sessions) {
+		if (session.step_type === "focus") {
+			const project = session.project_name || "Uncategorized";
+			projectMinutes[project] = (projectMinutes[project] || 0) + session.duration_min;
+			totalMinutes += session.duration_min;
+		}
+	}
+
+	return Object.entries(projectMinutes)
+		.map(([project, minutes]) => ({
+			project,
+			minutes,
+			percentage: totalMinutes > 0 ? Math.round((minutes / totalMinutes) * 100) : 0,
+		}))
+		.sort((a, b) => b.minutes - a.minutes);
+}
+
+/**
+ * Analyze daily patterns
+ */
+function getDailyPatterns(sessions: SessionData[]): Record<string, number> {
+	const dayMinutes: Record<string, number> = {
+		Mon: 0,
+		Tue: 0,
+		Wed: 0,
+		Thu: 0,
+		Fri: 0,
+		Sat: 0,
+		Sun: 0,
+	};
+
+	for (const session of sessions) {
+		if (session.step_type === "focus") {
+			const date = new Date(session.completed_at);
+			const dayName = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"][date.getDay()];
+			dayMinutes[dayName] += session.duration_min;
+		}
+	}
+
+	return dayMinutes;
+}
+
+/**
+ * Identify peak productivity day
+ */
+function getPeakDay(dayMinutes: Record<string, number>): string {
+	let peakDay = "Mon";
+	let peakMinutes = 0;
+
+	for (const [day, minutes] of Object.entries(dayMinutes)) {
+		if (minutes > peakMinutes) {
+			peakMinutes = minutes;
+			peakDay = day;
+		}
+	}
+
+	return peakDay;
+}
+
+/**
+ * Calculate session completion rate
+ */
+function getSessionStats(sessions: SessionData[]): {
+	total: number;
+	focus: number;
+	break: number;
+	avgFocusDuration: number;
+} {
+	const focus = sessions.filter((s) => s.step_type === "focus").length;
+	const breakCount = sessions.filter((s) => s.step_type === "break").length;
+	const focusSessions = sessions.filter((s) => s.step_type === "focus");
+	const totalFocusMinutes = focusSessions.reduce((sum, s) => sum + s.duration_min, 0);
+
+	return {
+		total: sessions.length,
+		focus,
+		break: breakCount,
+		avgFocusDuration: focus > 0 ? Math.round(totalFocusMinutes / focus) : 0,
+	};
+}
+
+/**
+ * Format minutes to human-readable string
+ */
+function formatDuration(minutes: number): string {
+	if (minutes < 60) {
+		return `${minutes}分`;
+	}
+	const hours = Math.floor(minutes / 60);
+	const mins = minutes % 60;
+	return mins > 0 ? `${hours}時間${mins}分` : `${hours}時間`;
+}
+
+/**
+ * Generate weekly retrospective
+ */
+export function generateWeeklyRetro(data: WeeklyRetroData): WeeklyRetro {
+	const { weekStart, weekEnd, sessions, stats } = data;
+
+	const projectDistribution = getProjectDistribution(sessions);
+	const dailyPatterns = getDailyPatterns(sessions);
+	const peakDay = getPeakDay(dailyPatterns);
+	const sessionStats = getSessionStats(sessions);
+
+	// Format date range
+	const formatDate = (dateStr: string) => {
+		const d = new Date(dateStr);
+		return `${d.getMonth() + 1}/${d.getDate()}`;
+	};
+	const periodStr = `${formatDate(weekStart)} - ${formatDate(weekEnd)}`;
+
+	// Generate achievements
+	const achievements: string[] = [
+		`📊 合計フォーカス時間: ${formatDuration(stats.totalFocusMinutes)}`,
+		`✅ 完了セッション数: ${sessionStats.focus}回`,
+		`🏆 ピークパフォーマンス: ${peakDay}曜日`,
+	];
+
+	// Add top projects
+	if (projectDistribution.length > 0) {
+		const topProject = projectDistribution[0];
+		achievements.push(
+			`🎯 最も取り組んだプロジェクト: ${topProject.project} (${formatDuration(topProject.minutes)})`,
+		);
+	}
+
+	// Generate challenges
+	const challenges: string[] = [];
+
+	// Check for low activity days
+	const lowActivityDays = Object.entries(dailyPatterns)
+		.filter(([, minutes]) => minutes === 0)
+		.map(([day]) => day);
+
+	if (lowActivityDays.length > 0) {
+		challenges.push(`📉 活動なし: ${lowActivityDays.join(", ")}曜日`);
+	}
+
+	// Check break ratio
+	if (sessionStats.focus > 0) {
+		const breakRatio = sessionStats.break / sessionStats.focus;
+		if (breakRatio < 0.2) {
+			challenges.push("⚠️ 休憩が少ない傾向 - 定期的な休憩を推奨");
+		}
+	}
+
+	// Check for short sessions
+	if (sessionStats.avgFocusDuration < 20 && sessionStats.focus > 0) {
+		challenges.push("⏱️ 平均セッション時間が短め - 集中時間の延長を検討");
+	}
+
+	if (challenges.length === 0) {
+		challenges.push("✨ 特筆すべき課題はありません - 順調な週でした");
+	}
+
+	// Generate improvements
+	const improvements: string[] = [];
+
+	if (projectDistribution.length > 3) {
+		improvements.push(
+			"📌 プロジェクト数が多め - 優先度の高いものに集中することを検討",
+		);
+	}
+
+	if (dailyPatterns.Sat > 0 || dailyPatterns.Sun > 0) {
+		improvements.push("💪 週末も活動的 - ワークライフバランスを意識");
+	}
+
+	if (stats.totalFocusMinutes > 1200) {
+		// 20+ hours
+		improvements.push("🔥 非常に高い生産性 - 継続的な休息も大切に");
+	}
+
+	improvements.push("📈 次週も継続して記録を活用し、改善を続けましょう");
+
+	// Generate next week goals based on data
+	const nextWeekGoals: string[] = [
+		`目標フォーカス時間: ${formatDuration(Math.max(stats.totalFocusMinutes, 600))}`,
+		"毎日のセッション記録を継続",
+		"定期的な休憩の実施",
+	];
+
+	if (projectDistribution.length > 0) {
+		nextWeekGoals.push(`優先プロジェクト: ${projectDistribution[0].project}の推進`);
+	}
+
+	// Generate summary
+	const summary = `今週は${sessionStats.focus}回のフォーカスセッションで合計${formatDuration(stats.totalFocusMinutes)}活動しました。${peakDay}曜日が最も生産的でした。`;
+
+	// Generate raw markdown
+	const rawMarkdown = `# 週次振り返り
+
+**期間**: ${periodStr}
+
+## サマリー
+
+${summary}
+
+## 成果 🎉
+
+${achievements.map((a) => `- ${a}`).join("\n")}
+
+## 課題 🔍
+
+${challenges.map((c) => `- ${c}`).join("\n")}
+
+## 改善点 💡
+
+${improvements.map((i) => `- ${i}`).join("\n")}
+
+## 来週の目標 🎯
+
+${nextWeekGoals.map((g) => `- ${g}`).join("\n")}
+
+---
+
+### プロジェクト別時間
+
+${projectDistribution
+	.slice(0, 5)
+	.map((p) => `- **${p.project}**: ${formatDuration(p.minutes)} (${p.percentage}%)`)
+	.join("\n")}
+
+### 曜日別活動
+
+| 曜日 | フォーカス時間 |
+|------|---------------|
+${Object.entries(dailyPatterns)
+	.map(([day, mins]) => `| ${day} | ${formatDuration(mins)} |`)
+	.join("\n")}
+
+---
+*Generated by Pomodoroom on ${new Date().toLocaleDateString("ja-JP")}*
+`;
+
+	return {
+		title: `週次振り返り (${periodStr})`,
+		period: periodStr,
+		summary,
+		achievements: { title: "成果", items: achievements },
+		challenges: { title: "課題", items: challenges },
+		improvements: { title: "改善点", items: improvements },
+		nextWeekGoals: { title: "来週の目標", items: nextWeekGoals },
+		rawMarkdown,
+	};
+}
+
+/**
+ * Get week range for a given date
+ */
+export function getWeekRange(date: Date): { start: string; end: string } {
+	const d = new Date(date);
+	const day = d.getDay();
+	const diff = d.getDate() - day + (day === 0 ? -6 : 1); // Monday as start
+	d.setDate(diff);
+	const start = new Date(d);
+	d.setDate(d.getDate() + 6);
+	const end = new Date(d);
+
+	const formatDate = (dt: Date) => dt.toISOString().slice(0, 10);
+	return { start: formatDate(start), end: formatDate(end) };
+}
+
+/**
+ * Copy retro to clipboard
+ */
+export async function copyRetroToClipboard(retro: WeeklyRetro): Promise<boolean> {
+	try {
+		await navigator.clipboard.writeText(retro.rawMarkdown);
+		return true;
+	} catch {
+		return false;
+	}
+}

--- a/src/views/WeeklyRetroView.tsx
+++ b/src/views/WeeklyRetroView.tsx
@@ -1,0 +1,147 @@
+/**
+ * WeeklyRetroView - Weekly retrospective view
+ *
+ * Displays auto-generated weekly retrospective based on
+ * session data with achievements, challenges, and improvements.
+ */
+
+import { useEffect, useState, useCallback } from "react";
+import { Button } from "@/components/m3/Button";
+import { Icon, type MSIconName } from "@/components/m3/Icon";
+import { useStats } from "@/hooks/useStats";
+import {
+	generateWeeklyRetro,
+	getWeekRange,
+	copyRetroToClipboard,
+	type WeeklyRetro,
+} from "@/utils/weeklyRetroGenerator";
+
+export function WeeklyRetroView() {
+	const { sessions, stats, loadWeek, loading } = useStats();
+	const [retro, setRetro] = useState<WeeklyRetro | null>(null);
+	const [copied, setCopied] = useState(false);
+
+	useEffect(() => {
+		loadWeek();
+	}, [loadWeek]);
+
+	useEffect(() => {
+		if (sessions.length > 0) {
+			const { start, end } = getWeekRange(new Date());
+			const generated = generateWeeklyRetro({
+				weekStart: start,
+				weekEnd: end,
+				sessions,
+				stats,
+			});
+			setRetro(generated);
+		}
+	}, [sessions, stats]);
+
+	const handleCopy = useCallback(async () => {
+		if (retro) {
+			const success = await copyRetroToClipboard(retro);
+			if (success) {
+				setCopied(true);
+				setTimeout(() => setCopied(false), 2000);
+			}
+		}
+	}, [retro]);
+
+	const handleExport = useCallback(() => {
+		if (retro) {
+			const blob = new Blob([retro.rawMarkdown], { type: "text/markdown" });
+			const url = URL.createObjectURL(blob);
+			const a = document.createElement("a");
+			a.href = url;
+			a.download = `weekly-retro-${retro.period.replace(/\s/g, "")}.md`;
+			a.click();
+			URL.revokeObjectURL(url);
+		}
+	}, [retro]);
+
+	if (loading) {
+		return (
+			<div className="w-full h-full flex items-center justify-center bg-[var(--md-ref-color-surface)]">
+				<div className="animate-spin">
+					<Icon name="refresh" size={24} />
+				</div>
+			</div>
+		);
+	}
+
+	if (!retro) {
+		return (
+			<div className="w-full h-full flex flex-col items-center justify-center bg-[var(--md-ref-color-surface)] gap-4">
+				<Icon name="info" size={48} className="text-[var(--md-ref-color-on-surface-variant)]" />
+				<p className="text-[var(--md-ref-color-on-surface-variant)]">
+					今週のデータがありません
+				</p>
+			</div>
+		);
+	}
+
+	return (
+		<div className="w-full h-full flex flex-col bg-[var(--md-ref-color-surface)]">
+			{/* Header */}
+			<div className="flex items-center justify-between px-4 py-3 border-b border-[var(--md-ref-color-outline-variant)]">
+				<div className="flex items-center gap-2">
+					<Icon name="description" size={24} />
+					<h1 className="text-lg font-semibold">{retro.title}</h1>
+				</div>
+				<div className="flex gap-2">
+					<Button variant="text" size="small" onClick={handleCopy}>
+						<Icon name="link" size={18} />
+						{copied ? "コピー済み" : "コピー"}
+					</Button>
+					<Button variant="text" size="small" onClick={handleExport}>
+						<Icon name="download" size={18} />
+						エクスポート
+					</Button>
+				</div>
+			</div>
+
+			{/* Content */}
+			<div className="flex-1 overflow-auto p-4">
+				{/* Summary */}
+				<div className="mb-6 p-4 rounded-lg bg-[var(--md-ref-color-surface-container)]">
+					<p className="text-sm text-[var(--md-ref-color-on-surface)]">{retro.summary}</p>
+				</div>
+
+				{/* Sections */}
+				<div className="grid gap-4">
+					<RetroSectionComponent section={retro.achievements} icon="check_circle" color="var(--md-ref-color-primary)" />
+					<RetroSectionComponent section={retro.challenges} icon="search" color="var(--md-ref-color-error)" />
+					<RetroSectionComponent section={retro.improvements} icon="auto_awesome" color="var(--md-ref-color-tertiary)" />
+					<RetroSectionComponent section={retro.nextWeekGoals} icon="flag" color="var(--md-ref-color-secondary)" />
+				</div>
+			</div>
+		</div>
+	);
+}
+
+interface RetroSectionProps {
+	section: { title: string; items: string[] };
+	icon: MSIconName;
+	color: string;
+}
+
+function RetroSectionComponent({ section, icon, color }: RetroSectionProps) {
+	return (
+		<div className="p-4 rounded-lg bg-[var(--md-ref-color-surface-container-low)]">
+			<div className="flex items-center gap-2 mb-3">
+				<Icon name={icon} size={20} style={{ color }} />
+				<h2 className="text-sm font-semibold">{section.title}</h2>
+			</div>
+			<ul className="space-y-2">
+				{section.items.map((item, index) => (
+					<li key={index} className="text-sm text-[var(--md-ref-color-on-surface-variant)] pl-2 border-l-2" style={{ borderColor: color }}>
+						{item}
+					</li>
+				))}
+			</ul>
+		</div>
+	);
+}
+
+export default WeeklyRetroView;


### PR DESCRIPTION
## Summary

- 週次振り返りドキュメントを自動生成
- セッションデータから成果・課題・改善点を分析
- Markdownエクスポート機能付き

## Features

### 成果 (Achievements)
- 合計フォーカス時間
- 完了セッション数
- ピークパフォーマンス曜日
- 最も取り組んだプロジェクト

### 課題 (Challenges)
- 活動なし曜日の検出
- 休憩不足の警告
- 短いセッション時間の指摘

### 改善点 (Improvements)
- プロジェクト数に応じたアドバイス
- ワークライフバランスの意識
- 生産性に応じた休息の推奨

### 分析機能
- プロジェクト別時間分布
- 曜日別活動パターン
- 休憩比率分析

## Files Changed

- `src/utils/weeklyRetroGenerator.ts` (新規) - ロジック
- `src/views/WeeklyRetroView.tsx` (新規) - UI

## Test Plan

- [x] `pnpm run check` - 59 tests passed

Closes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)