### PR TITLE
feat: move useIntegrations to tauri bridge source-of-truth

### DIFF
--- a/src/components/IntegrationsPanel.tsx
+++ b/src/components/IntegrationsPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Icon } from "@/components/m3/Icon";
 import { IntegrationIcon } from "@/components/IntegrationIcon";
 import { useGoogleCalendar } from "@/hooks/useGoogleCalendar";
@@ -20,15 +20,19 @@ export function IntegrationsPanel({ theme }: IntegrationsPanelProps) {
 
 	const {
 		services,
-		connectedServices,
 		getServiceConfig,
 		disconnectService,
 		syncService,
 	} = useIntegrations();
-	const totalConnectedServices =
-		connectedServices.length +
-		(googleCalendar.state.isConnected ? 1 : 0) +
-		(googleTasks.state.isConnected ? 1 : 0);
+	const totalConnectedServices = useMemo(
+		() =>
+			services.filter((service) => {
+				if (service.id === "google_calendar") return googleCalendar.state.isConnected;
+				if (service.id === "google_tasks") return googleTasks.state.isConnected;
+				return getServiceConfig(service.id).connected;
+			}).length,
+		[services, googleCalendar.state.isConnected, googleTasks.state.isConnected, getServiceConfig],
+	);
 
 	const handleConnect = async (serviceId: IntegrationService) => {
 		if (serviceId === "google_calendar") {

--- a/src/hooks/useIntegrations.test.tsx
+++ b/src/hooks/useIntegrations.test.tsx
@@ -3,10 +3,24 @@ import { describe, expect, it, beforeEach, vi } from "vitest";
 import { INTEGRATION_SERVICES } from "@/types";
 import { useIntegrations } from "./useIntegrations";
 
+const mockIsTauriEnvironment = vi.fn(() => false);
+const mockInvoke = vi.fn();
+
+vi.mock("@/lib/tauriEnv", () => ({
+	isTauriEnvironment: () => mockIsTauriEnvironment(),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+	invoke: (...args: unknown[]) => mockInvoke(...args),
+}));
+
 describe("integration service id normalization", () => {
   beforeEach(() => {
     localStorage.clear();
     vi.restoreAllMocks();
+    mockInvoke.mockReset();
+    mockIsTauriEnvironment.mockReset();
+    mockIsTauriEnvironment.mockReturnValue(false);
     vi.spyOn(console, "warn").mockImplementation(() => undefined);
   });
 
@@ -43,5 +57,91 @@ describe("integration service id normalization", () => {
     const parsed = JSON.parse(raw as string) as Record<string, unknown>;
     expect(parsed.google).toBeUndefined();
     expect(parsed.google_calendar).toBeTruthy();
+  });
+
+  it("loads connection state from tauri integration bridge", async () => {
+    mockIsTauriEnvironment.mockReturnValue(true);
+    mockInvoke.mockImplementation((command: string) => {
+      if (command === "cmd_integration_list") {
+        return Promise.resolve([
+          {
+            service: "google_calendar",
+            connected: true,
+            last_sync: "2026-02-15T03:00:00.000Z",
+          },
+          {
+            service: "notion",
+            connected: false,
+            last_sync: null,
+          },
+        ]);
+      }
+      return Promise.resolve(null);
+    });
+
+    const { result } = renderHook(() => useIntegrations());
+
+    await waitFor(() => {
+      const google = result.current.getServiceConfig("google_calendar");
+      expect(google.connected).toBe(true);
+      expect(google.lastSyncAt).toBe("2026-02-15T03:00:00.000Z");
+    });
+
+    expect(mockInvoke).toHaveBeenCalledWith("cmd_integration_list");
+  });
+
+  it("uses tauri commands for disconnect and sync", async () => {
+    mockIsTauriEnvironment.mockReturnValue(true);
+    mockInvoke.mockImplementation((command: string, args?: Record<string, unknown>) => {
+      if (command === "cmd_integration_list") {
+        return Promise.resolve([
+          {
+            service: "notion",
+            connected: true,
+            last_sync: "2026-02-15T03:00:00.000Z",
+          },
+        ]);
+      }
+      if (command === "cmd_integration_disconnect") {
+        expect(args).toEqual({ serviceName: "notion" });
+        return Promise.resolve(null);
+      }
+      if (command === "cmd_integration_get_status") {
+        if (args?.serviceName === "notion") {
+          return Promise.resolve({
+            service: "notion",
+            connected: false,
+            last_sync: null,
+          });
+        }
+      }
+      if (command === "cmd_integration_sync") {
+        expect(args).toEqual({ serviceName: "notion" });
+        return Promise.resolve({
+          service: "notion",
+          synced_at: "2026-02-15T04:00:00.000Z",
+          status: "success",
+        });
+      }
+      return Promise.resolve(null);
+    });
+
+    const { result } = renderHook(() => useIntegrations());
+
+    await waitFor(() => {
+      expect(result.current.getServiceConfig("notion").connected).toBe(true);
+    });
+
+    result.current.disconnectService("notion");
+
+    await waitFor(() => {
+      expect(result.current.getServiceConfig("notion").connected).toBe(false);
+    });
+
+    result.current.syncService("notion");
+
+    await waitFor(() => {
+      expect(result.current.getServiceConfig("notion").lastSyncAt).toBe("2026-02-15T04:00:00.000Z");
+    });
   });
 });


### PR DESCRIPTION
## Summary
- migrate `useIntegrations` from localStorage-first to Tauri bridge source-of-truth in desktop mode
- load/refetch statuses via `cmd_integration_list` and per-service refresh via `cmd_integration_get_status`
- route disconnect/sync through `cmd_integration_disconnect` and `cmd_integration_sync`
- keep localStorage path only for non-Tauri preview
- fix connected service count in IntegrationsPanel to avoid google double counting

## Testing
- npm run test -- src/hooks/useIntegrations.test.tsx
- npm run type-check

Closes #267
