### PR TITLE
feat: add overfocus guard with enforced cooldown

### DIFF
--- a/src/utils/overfocus-guard.test.ts
+++ b/src/utils/overfocus-guard.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+	applyOverfocusCooldown,
+	getOverfocusOverrideLogs,
+} from "@/utils/overfocus-guard";
+
+describe("overfocus guard", () => {
+	beforeEach(() => {
+		localStorage.clear();
+	});
+
+	it("enforces minimum cooldown only when threshold is exceeded", () => {
+		expect(
+			applyOverfocusCooldown({
+				streakLevel: 3,
+				breakMinutes: 5,
+				availableGapMinutes: 30,
+				threshold: 3,
+				minCooldownMinutes: 15,
+			}),
+		).toBe(5);
+
+		expect(
+			applyOverfocusCooldown({
+				streakLevel: 4,
+				breakMinutes: 5,
+				availableGapMinutes: 30,
+				threshold: 3,
+				minCooldownMinutes: 15,
+			}),
+		).toBe(15);
+	});
+
+	it("logs explicit override and keeps original break", () => {
+		const next = applyOverfocusCooldown({
+			streakLevel: 6,
+			breakMinutes: 5,
+			availableGapMinutes: 30,
+			threshold: 3,
+			minCooldownMinutes: 20,
+			overrideAcknowledged: true,
+			overrideReason: "manual-continue",
+		});
+
+		expect(next).toBe(5);
+		const logs = getOverfocusOverrideLogs();
+		expect(logs).toHaveLength(1);
+		expect(logs[0]?.reason).toBe("manual-continue");
+	});
+});

--- a/src/utils/overfocus-guard.ts
+++ b/src/utils/overfocus-guard.ts
@@ -1,0 +1,68 @@
+const STORAGE_KEY = "pomodoroom-overfocus-override-logs";
+
+export interface OverfocusOverrideLog {
+	at: string;
+	reason: string;
+	streakLevel: number;
+	breakMinutes: number;
+	minCooldownMinutes: number;
+}
+
+export interface OverfocusCooldownInput {
+	streakLevel: number;
+	breakMinutes: number;
+	availableGapMinutes?: number;
+	threshold: number;
+	minCooldownMinutes: number;
+	overrideAcknowledged?: boolean;
+	overrideReason?: string;
+}
+
+function clamp(value: number, min: number, max: number): number {
+	return Math.max(min, Math.min(max, value));
+}
+
+function appendOverrideLog(entry: OverfocusOverrideLog): void {
+	try {
+		const current = getOverfocusOverrideLogs();
+		current.push(entry);
+		if (current.length > 200) current.splice(0, current.length - 200);
+		localStorage.setItem(STORAGE_KEY, JSON.stringify(current));
+	} catch {
+		// Ignore storage failures.
+	}
+}
+
+export function getOverfocusOverrideLogs(): OverfocusOverrideLog[] {
+	try {
+		const raw = localStorage.getItem(STORAGE_KEY);
+		if (!raw) return [];
+		const parsed = JSON.parse(raw) as OverfocusOverrideLog[];
+		return Array.isArray(parsed) ? parsed : [];
+	} catch {
+		return [];
+	}
+}
+
+export function applyOverfocusCooldown(input: OverfocusCooldownInput): number {
+	const availableMax = Math.max(1, input.availableGapMinutes ?? Number.MAX_SAFE_INTEGER);
+	const baseBreak = clamp(input.breakMinutes, 1, availableMax);
+
+	if (input.streakLevel <= input.threshold) {
+		return baseBreak;
+	}
+
+	if (input.overrideAcknowledged) {
+		appendOverrideLog({
+			at: new Date().toISOString(),
+			reason: input.overrideReason ?? "user-override",
+			streakLevel: input.streakLevel,
+			breakMinutes: input.breakMinutes,
+			minCooldownMinutes: input.minCooldownMinutes,
+		});
+		return baseBreak;
+	}
+
+	const enforced = Math.max(baseBreak, input.minCooldownMinutes);
+	return clamp(enforced, 1, availableMax);
+}


### PR DESCRIPTION
## Summary
- add overfocus guard utility to enforce cooldown when consecutive focus streak exceeds threshold
- apply guard in auto break generation for both split-focus breaks and task-gap breaks
- support explicit user override with analytics log persistence
- ensure scheduler avoids deadlock by clamping enforced cooldown to available gap
- add tests for trigger threshold, override logging, and no-deadlock scheduling flow

## Testing
- npm run test -- src/utils/overfocus-guard.test.ts src/utils/auto-schedule-time.test.ts
- npm run type-check

Closes #208
