### PR TITLE
Add source deduplication for integration task imports (#281)

### DIFF
--- a/crates/pomodoroom-core/src/schedule/mod.rs
+++ b/crates/pomodoroom-core/src/schedule/mod.rs
@@ -139,6 +139,8 @@ mod tests {
             updated_at: Utc::now(),
             completed_at: None,
             paused_at: None,
+            source_service: None,
+            source_external_id: None,
         };
 
         let json = serde_json::to_string(&task).unwrap();

--- a/crates/pomodoroom-core/src/scheduler/mod.rs
+++ b/crates/pomodoroom-core/src/scheduler/mod.rs
@@ -481,6 +481,8 @@ mod tests {
             updated_at: Utc::now(),
             completed_at: None,
             paused_at: None,
+            source_service: None,
+            source_external_id: None,
         }
     }
 
@@ -520,6 +522,8 @@ mod tests {
             updated_at: Utc::now(),
             completed_at: None,
             paused_at: None,
+            source_service: None,
+            source_external_id: None,
         }
     }
 

--- a/crates/pomodoroom-core/src/task/mod.rs
+++ b/crates/pomodoroom-core/src/task/mod.rs
@@ -203,6 +203,10 @@ pub struct Task {
     pub completed_at: Option<DateTime<Utc>>,
     /// Pause timestamp (null if not paused) - for ambient display
     pub paused_at: Option<DateTime<Utc>>,
+    /// Integration service name (e.g., "google_tasks", "notion", "linear")
+    pub source_service: Option<String>,
+    /// External task ID from the integration service (for deduplication)
+    pub source_external_id: Option<String>,
 }
 
 impl Task {
@@ -239,6 +243,8 @@ impl Task {
             updated_at: now,
             completed_at: None,
             paused_at: None,
+            source_service: None,
+            source_external_id: None,
         }
     }
 
@@ -686,6 +692,8 @@ mod tests {
             updated_at: Utc::now(),
             completed_at: None,
             paused_at: None,
+            source_service: None,
+            source_external_id: None,
         };
 
         let json = serde_json::to_string(&task).unwrap();


### PR DESCRIPTION
## Summary
Implements #281: Add unique constraint on `source_external_id` to prevent duplicate task imports from external integrations like Google Tasks.

## Changes
- Add `source_service` and `source_external_id` fields to `Task` model
- Add migration v7 to add these columns to tasks table
- Add unique index on `(source_service, source_external_id)` for deduplication
- Add `upsert_task_from_source()` function for merge/upsert on import
- Update all test cases to include new fields

## Test Results
- Core: 135 tests passed
- Frontend: 69 tests passed (23 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)