### PR TITLE
[Impl] [Idea][Schedule] Event-driven replanning on calendar updates

### DIFF
--- a/docs/issues/217-idea-schedule-event-driven-replanning-on.md
+++ b/docs/issues/217-idea-schedule-event-driven-replanning-on.md
@@ -1,0 +1,29 @@
+﻿# Issue #217
+
+- URL: https://github.com/rebuildup/pomodoroom/issues/217
+- Branch: issue-217-idea-schedule-event-driven-replanning-on
+
+## Implementation Plan
+- [ ] Read issue + related files
+- [ ] Add/adjust tests first
+- [ ] Implement minimal solution
+- [ ] Run checks
+- [ ] Open PR with Closes #217
+
+## Notes
+
+### Implemented
+
+- Added `event-driven-replan` utility module:
+  - detect impacted window from calendar event delta
+  - local-horizon merge (preserve/lock unaffected blocks)
+  - diff generation for inspection before apply
+  - churn metric outside impacted window
+- Extended `useScheduler`:
+  - `previewReplanOnCalendarUpdates(...)` to generate a replan preview
+  - `applyReplanPreview(...)` to commit previewed schedule blocks
+- Added tests validating:
+  - impacted window detection with padding
+  - minimal churn outside impacted window
+  - diff generation for changed local horizon
+

--- a/src/utils/event-driven-replan.test.ts
+++ b/src/utils/event-driven-replan.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import type { ScheduleBlock } from "@/types/schedule";
+import {
+	buildReplanDiff,
+	calculateChurnOutsideWindow,
+	detectImpactedWindowFromCalendarDelta,
+	mergeLocalReplan,
+} from "./event-driven-replan";
+
+function block(
+	id: string,
+	startTime: string,
+	endTime: string,
+	label?: string
+): ScheduleBlock {
+	return {
+		id,
+		blockType: "focus",
+		startTime,
+		endTime,
+		locked: false,
+		label,
+	};
+}
+
+describe("event-driven-replan", () => {
+	it("detects impacted window from calendar deltas with padding", () => {
+		const previous = [
+			block("cal-1", "2026-02-16T10:00:00.000Z", "2026-02-16T11:00:00.000Z"),
+		];
+		const next = [
+			block("cal-1", "2026-02-16T10:30:00.000Z", "2026-02-16T11:30:00.000Z"),
+		];
+
+		const window = detectImpactedWindowFromCalendarDelta(previous, next, 10);
+		expect(window).not.toBeNull();
+		expect(window!.startTime).toBe("2026-02-16T09:50:00.000Z");
+		expect(window!.endTime).toBe("2026-02-16T11:40:00.000Z");
+	});
+
+	it("preserves and locks unaffected blocks while replacing impacted window", () => {
+		const current = [
+			block("b1", "2026-02-16T08:00:00.000Z", "2026-02-16T08:30:00.000Z"),
+			block("b2", "2026-02-16T10:00:00.000Z", "2026-02-16T10:30:00.000Z"),
+			block("b3", "2026-02-16T12:00:00.000Z", "2026-02-16T12:30:00.000Z"),
+		];
+		const replanned = [
+			block("b2-new", "2026-02-16T10:15:00.000Z", "2026-02-16T10:45:00.000Z"),
+		];
+		const window = {
+			startTime: "2026-02-16T09:45:00.000Z",
+			endTime: "2026-02-16T11:15:00.000Z",
+		};
+
+		const merged = mergeLocalReplan(current, replanned, window);
+
+		expect(merged.map((entry) => entry.id)).toEqual(["b1", "b2-new", "b3"]);
+		expect(merged.find((entry) => entry.id === "b1")?.locked).toBe(true);
+		expect(merged.find((entry) => entry.id === "b3")?.locked).toBe(true);
+	});
+
+	it("computes diff and reports zero churn outside impacted window", () => {
+		const before = [
+			block("stable", "2026-02-16T08:00:00.000Z", "2026-02-16T08:30:00.000Z"),
+			block("changed", "2026-02-16T10:00:00.000Z", "2026-02-16T10:30:00.000Z"),
+		];
+		const after = [
+			block("stable", "2026-02-16T08:00:00.000Z", "2026-02-16T08:30:00.000Z"),
+			block("changed", "2026-02-16T10:15:00.000Z", "2026-02-16T10:45:00.000Z"),
+		];
+		const window = {
+			startTime: "2026-02-16T09:45:00.000Z",
+			endTime: "2026-02-16T11:00:00.000Z",
+		};
+
+		const diff = buildReplanDiff(before, after, window);
+		const churn = calculateChurnOutsideWindow(before, after, window);
+
+		expect(diff).toHaveLength(1);
+		expect(diff[0]?.type).toBe("updated");
+		expect(churn).toBe(0);
+	});
+});
+

--- a/src/utils/event-driven-replan.ts
+++ b/src/utils/event-driven-replan.ts
@@ -1,0 +1,155 @@
+import type { ScheduleBlock } from "@/types/schedule";
+
+export interface ImpactedWindow {
+	startTime: string;
+	endTime: string;
+}
+
+export interface ReplanDiffItem {
+	id: string;
+	type: "added" | "removed" | "updated";
+	before?: ScheduleBlock;
+	after?: ScheduleBlock;
+}
+
+function toMs(iso: string): number {
+	return new Date(iso).getTime();
+}
+
+function withPadding(ms: number, minutes: number): number {
+	return ms + minutes * 60 * 1000;
+}
+
+function blockInWindow(block: ScheduleBlock, window: ImpactedWindow): boolean {
+	const start = toMs(block.startTime);
+	const end = toMs(block.endTime);
+	const windowStart = toMs(window.startTime);
+	const windowEnd = toMs(window.endTime);
+	return start < windowEnd && end > windowStart;
+}
+
+function sameBlockShape(a: ScheduleBlock, b: ScheduleBlock): boolean {
+	return (
+		a.startTime === b.startTime &&
+		a.endTime === b.endTime &&
+		a.blockType === b.blockType &&
+		(a.taskId ?? null) === (b.taskId ?? null) &&
+		(a.label ?? null) === (b.label ?? null) &&
+		(a.lane ?? 0) === (b.lane ?? 0)
+	);
+}
+
+export function detectImpactedWindowFromCalendarDelta(
+	previousEvents: ScheduleBlock[],
+	nextEvents: ScheduleBlock[],
+	paddingMinutes = 15
+): ImpactedWindow | null {
+	const previousById = new Map(previousEvents.map((event) => [event.id, event]));
+	const nextById = new Map(nextEvents.map((event) => [event.id, event]));
+	const ids = new Set([...previousById.keys(), ...nextById.keys()]);
+
+	let minStart = Number.POSITIVE_INFINITY;
+	let maxEnd = Number.NEGATIVE_INFINITY;
+	let changed = false;
+
+	for (const id of ids) {
+		const before = previousById.get(id);
+		const after = nextById.get(id);
+		if (!before || !after) {
+			const edge = before ?? after;
+			if (edge) {
+				minStart = Math.min(minStart, toMs(edge.startTime));
+				maxEnd = Math.max(maxEnd, toMs(edge.endTime));
+				changed = true;
+			}
+			continue;
+		}
+
+		if (!sameBlockShape(before, after)) {
+			minStart = Math.min(minStart, toMs(before.startTime), toMs(after.startTime));
+			maxEnd = Math.max(maxEnd, toMs(before.endTime), toMs(after.endTime));
+			changed = true;
+		}
+	}
+
+	if (!changed) {
+		return null;
+	}
+
+	return {
+		startTime: new Date(withPadding(minStart, -paddingMinutes)).toISOString(),
+		endTime: new Date(withPadding(maxEnd, paddingMinutes)).toISOString(),
+	};
+}
+
+export function mergeLocalReplan(
+	currentBlocks: ScheduleBlock[],
+	replannedBlocks: ScheduleBlock[],
+	window: ImpactedWindow
+): ScheduleBlock[] {
+	const preserved = currentBlocks
+		.filter((block) => !blockInWindow(block, window))
+		.map((block) => ({ ...block, locked: true }));
+
+	const localReplanned = replannedBlocks.filter((block) => blockInWindow(block, window));
+
+	return [...preserved, ...localReplanned].sort(
+		(a, b) => toMs(a.startTime) - toMs(b.startTime)
+	);
+}
+
+export function buildReplanDiff(
+	beforeBlocks: ScheduleBlock[],
+	afterBlocks: ScheduleBlock[],
+	window: ImpactedWindow
+): ReplanDiffItem[] {
+	const beforeWindow = beforeBlocks.filter((block) => blockInWindow(block, window));
+	const afterWindow = afterBlocks.filter((block) => blockInWindow(block, window));
+	const beforeById = new Map(beforeWindow.map((block) => [block.id, block]));
+	const afterById = new Map(afterWindow.map((block) => [block.id, block]));
+	const ids = new Set([...beforeById.keys(), ...afterById.keys()]);
+	const diff: ReplanDiffItem[] = [];
+
+	for (const id of ids) {
+		const before = beforeById.get(id);
+		const after = afterById.get(id);
+
+		if (!before && after) {
+			diff.push({ id, type: "added", after });
+			continue;
+		}
+		if (before && !after) {
+			diff.push({ id, type: "removed", before });
+			continue;
+		}
+		if (before && after && !sameBlockShape(before, after)) {
+			diff.push({ id, type: "updated", before, after });
+		}
+	}
+
+	return diff;
+}
+
+export function calculateChurnOutsideWindow(
+	beforeBlocks: ScheduleBlock[],
+	afterBlocks: ScheduleBlock[],
+	window: ImpactedWindow
+): number {
+	const beforeOutside = beforeBlocks.filter((block) => !blockInWindow(block, window));
+	const afterOutside = afterBlocks.filter((block) => !blockInWindow(block, window));
+	const beforeById = new Map(beforeOutside.map((block) => [block.id, block]));
+	const afterById = new Map(afterOutside.map((block) => [block.id, block]));
+	const ids = new Set([...beforeById.keys(), ...afterById.keys()]);
+	let churn = 0;
+
+	for (const id of ids) {
+		const before = beforeById.get(id);
+		const after = afterById.get(id);
+		if (!before || !after || !sameBlockShape(before, after)) {
+			churn += 1;
+		}
+	}
+
+	return churn;
+}
+


### PR DESCRIPTION
## Linked Issue
Closes #217

## What Changed
- 

## Why
- 

## Test Evidence
- [ ] pnpm run check
- [ ] cargo test -p pomodoroom-core
- [ ] cargo test -p pomodoroom-cli -- --test-threads=1
- [ ] Manual test done

## Screenshots / Logs (if needed)

## Risks
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * カレンダーイベント変更時に自動でスケジュールを再計画する機能を追加
  * リプラン結果をプレビュー確認してから適用可能に
  * 影響を受けるスケジュール区間を自動検出し、他の予定への影響を最小化

* **テスト**
  * イベント駆動型リプラン機能の包括的なテストを追加

* **ドキュメント**
  * リプラン機能の仕様書を追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->