### PR TITLE
[Idea][Energy] Detect task-energy mismatch before start

### DIFF
--- a/docs/issues/221-idea-energy-detect-task-energy-mismatch.md
+++ b/docs/issues/221-idea-energy-detect-task-energy-mismatch.md
@@ -1,0 +1,30 @@
+# Issue #221
+
+- URL: https://github.com/rebuildup/pomodoroom/issues/221
+- Branch: issue-221-idea-energy-detect-task-energy-mismatch
+
+## Implementation Plan
+- [x] Read issue + related files
+- [x] Add/adjust tests first
+- [x] Implement minimal solution
+- [x] Run checks
+- [ ] Open PR with Closes #221
+
+## Notes
+- Added `src/utils/task-energy-mismatch.ts` and tests (`src/utils/task-energy-mismatch.test.ts`).
+- Mismatch score now combines:
+  - task energy demand,
+  - estimated pressure,
+  - time-of-day,
+  - duration penalty.
+- Warnings only trigger when score >= threshold (default 60).
+- Added ranked alternatives with actionable flag and reason.
+- Added localStorage-based accept/reject tracking for mismatch suggestions:
+  - key: `energy_mismatch_feedback_stats`
+  - exposes false-positive proxy rate (`rejected/total`).
+- Integrated pre-start mismatch warning into:
+  - `src/views/ActionNotificationView.tsx` (`start_task` flow)
+  - `src/utils/window-task-operations.ts` (direct start ops)
+- Added bypass/decision fields to start action payload:
+  - `ignoreEnergyMismatch`
+  - `mismatchDecision` (`accepted` / `rejected`)

--- a/src/hooks/useActionNotification.ts
+++ b/src/hooks/useActionNotification.ts
@@ -15,7 +15,7 @@ export type NotificationAction =
 	| { resume: null }
 	| { skip: null }
 	| { start_next: null }
-	| { start_task: { id: string; resume: boolean } }
+	| { start_task: { id: string; resume: boolean; ignoreEnergyMismatch?: boolean; mismatchDecision?: "accepted" | "rejected" } }
 	| { start_later_pick: { id: string } }
 	| { complete_task: { id: string } }
 	| { extend_task: { id: string; minutes: number } }

--- a/src/utils/task-energy-mismatch.test.ts
+++ b/src/utils/task-energy-mismatch.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+	__resetEnergyMismatchFeedbackForTests,
+	evaluateTaskEnergyMismatch,
+	getEnergyMismatchFeedbackStats,
+	rankAlternativeTasks,
+	trackEnergyMismatchFeedback,
+} from "./task-energy-mismatch";
+
+describe("task-energy-mismatch", () => {
+	beforeEach(() => {
+		__resetEnergyMismatchFeedbackForTests();
+	});
+
+	it("triggers warning above threshold for high-demand task in low-capacity context", () => {
+		const result = evaluateTaskEnergyMismatch(
+			{ id: "t1", title: "Deep architecture", energy: "high", requiredMinutes: 90, priority: 50, state: "READY", tags: [] },
+			{ pressureValue: 85, now: new Date("2026-02-15T22:30:00.000Z") },
+		);
+
+		expect(result.shouldWarn).toBe(true);
+		expect(result.score).toBeGreaterThanOrEqual(result.threshold);
+		expect(result.reasons.length).toBeGreaterThan(0);
+	});
+
+	it("does not trigger warning below threshold in balanced context", () => {
+		const result = evaluateTaskEnergyMismatch(
+			{ id: "t2", title: "Routine update", energy: "medium", requiredMinutes: 25, priority: 50, state: "READY", tags: [] },
+			{ pressureValue: 20, now: new Date("2026-02-15T10:00:00.000Z") },
+		);
+
+		expect(result.shouldWarn).toBe(false);
+		expect(result.score).toBeLessThan(result.threshold);
+	});
+
+	it("ranks alternatives by lower mismatch and actionability", () => {
+		const alternatives = rankAlternativeTasks(
+			[
+				{ id: "current", title: "Deep architecture", energy: "high", requiredMinutes: 90, priority: 50, state: "READY", tags: ["deep"] },
+				{ id: "a", title: "Quick email", energy: "low", requiredMinutes: 15, priority: 40, state: "READY", tags: ["quick"] },
+				{ id: "b", title: "Docs touch-up", energy: "medium", requiredMinutes: 30, priority: 60, state: "READY", tags: [] },
+			],
+			"current",
+			{ pressureValue: 80, now: new Date("2026-02-15T22:30:00.000Z") },
+			2,
+		);
+
+		expect(alternatives).toHaveLength(2);
+		expect(alternatives[0]?.task.id).toBe("a");
+		expect(alternatives[0]?.actionable).toBe(true);
+	});
+
+	it("tracks accepted/rejected outcomes for false-positive monitoring", () => {
+		trackEnergyMismatchFeedback("accepted");
+		trackEnergyMismatchFeedback("rejected");
+		trackEnergyMismatchFeedback("rejected");
+
+		const stats = getEnergyMismatchFeedbackStats();
+		expect(stats.accepted).toBe(1);
+		expect(stats.rejected).toBe(2);
+		expect(stats.total).toBe(3);
+		expect(stats.falsePositiveRate).toBeCloseTo(2 / 3, 4);
+	});
+});

--- a/src/utils/task-energy-mismatch.ts
+++ b/src/utils/task-energy-mismatch.ts
@@ -1,0 +1,215 @@
+import type { EnergyLevel } from "@/types/task";
+
+export interface EnergyMismatchTaskLike {
+	id: string;
+	title: string;
+	energy: EnergyLevel;
+	requiredMinutes?: number | null;
+	priority?: number | null;
+	state?: string;
+	tags?: string[];
+}
+
+export interface EnergyMismatchContext {
+	pressureValue: number;
+	now?: Date;
+	threshold?: number;
+}
+
+export interface EnergyMismatchEvaluation {
+	shouldWarn: boolean;
+	score: number;
+	threshold: number;
+	reasons: string[];
+	suggestedSegmentMinutes: number;
+	currentCapacity: EnergyLevel;
+}
+
+export interface RankedAlternative {
+	task: EnergyMismatchTaskLike;
+	score: number;
+	actionable: boolean;
+	reason: string;
+}
+
+type FeedbackDecision = "accepted" | "rejected";
+
+const FEEDBACK_STORAGE_KEY = "energy_mismatch_feedback_stats";
+const DEFAULT_THRESHOLD = 60;
+
+function energyToIndex(level: EnergyLevel): number {
+	switch (level) {
+		case "low":
+			return 0;
+		case "medium":
+			return 1;
+		case "high":
+			return 2;
+	}
+}
+
+function getRequiredMinutes(task: EnergyMismatchTaskLike): number {
+	const raw = task.requiredMinutes ?? 25;
+	return Number.isFinite(raw) ? Math.max(1, Math.round(raw)) : 25;
+}
+
+export function inferCurrentCapacity(pressureValue: number, now: Date = new Date()): EnergyLevel {
+	const hour = now.getHours();
+
+	if (pressureValue >= 80) return "low";
+	if (pressureValue >= 60) return hour >= 18 ? "low" : "medium";
+	if (hour >= 22 || hour < 7) return "low";
+	if (hour >= 9 && hour < 12 && pressureValue <= 35) return "high";
+	if (hour >= 13 && hour < 17 && pressureValue <= 45) return "high";
+	return "medium";
+}
+
+export function evaluateTaskEnergyMismatch(
+	task: EnergyMismatchTaskLike,
+	context: EnergyMismatchContext,
+): EnergyMismatchEvaluation {
+	const now = context.now ?? new Date();
+	const threshold = context.threshold ?? DEFAULT_THRESHOLD;
+	const requiredMinutes = getRequiredMinutes(task);
+	const currentCapacity = inferCurrentCapacity(context.pressureValue, now);
+	const demand = energyToIndex(task.energy);
+	const capacity = energyToIndex(currentCapacity);
+	const gap = Math.max(0, demand - capacity);
+	const reasons: string[] = [];
+	let score = 0;
+
+	if (gap > 0) {
+		score += gap * 35;
+		reasons.push(`Energy gap: task=${task.energy}, current=${currentCapacity}`);
+	}
+
+	if (context.pressureValue >= 70 && task.energy !== "low") {
+		score += 20;
+		reasons.push(`High pressure (${context.pressureValue}) vs non-low task`);
+	} else if (context.pressureValue >= 50 && task.energy === "high") {
+		score += 12;
+		reasons.push(`Moderate pressure (${context.pressureValue}) with high-energy task`);
+	}
+
+	const hour = now.getHours();
+	if ((hour >= 21 || hour < 7) && task.energy === "high") {
+		score += 20;
+		reasons.push("Late-night high-energy task");
+	} else if ((hour >= 22 || hour < 6) && task.energy === "medium") {
+		score += 10;
+		reasons.push("Late-night medium-energy task");
+	}
+
+	if (requiredMinutes >= 60 && currentCapacity === "low") {
+		score += 15;
+		reasons.push(`Long session (${requiredMinutes}m) in low capacity`);
+	} else if (requiredMinutes >= 90) {
+		score += 8;
+		reasons.push(`Very long session (${requiredMinutes}m)`);
+	}
+
+	if (task.tags?.includes("quick") && requiredMinutes <= 20) {
+		score -= 8;
+	}
+
+	const clampedScore = Math.max(0, Math.min(100, Math.round(score)));
+	const suggestedSegmentMinutes = currentCapacity === "low" ? 20 : currentCapacity === "medium" ? 35 : 50;
+
+	return {
+		shouldWarn: clampedScore >= threshold,
+		score: clampedScore,
+		threshold,
+		reasons,
+		suggestedSegmentMinutes,
+		currentCapacity,
+	};
+}
+
+export function rankAlternativeTasks(
+	tasks: readonly EnergyMismatchTaskLike[],
+	currentTaskId: string,
+	context: EnergyMismatchContext,
+	limit: number = 3,
+): RankedAlternative[] {
+	const scored = tasks
+		.filter((task) => task.id !== currentTaskId)
+		.filter((task) => task.state === undefined || task.state === "READY" || task.state === "PAUSED")
+		.map((task) => {
+			const mismatch = evaluateTaskEnergyMismatch(task, context);
+			const requiredMinutes = getRequiredMinutes(task);
+			const priority = task.priority ?? 50;
+			const quickBonus = requiredMinutes <= 25 ? 10 : 0;
+			const priorityBonus = Math.max(-10, Math.min(10, Math.round((priority - 50) / 5)));
+			const score = Math.max(0, Math.min(100, 100 - mismatch.score + quickBonus + priorityBonus));
+			return {
+				task,
+				score,
+				actionable: score >= 45,
+				reason: mismatch.shouldWarn
+					? `Lower mismatch (${mismatch.score}) than current context`
+					: `Good fit for ${mismatch.currentCapacity} capacity now`,
+			};
+		})
+		.sort((a, b) => b.score - a.score);
+
+	return scored.slice(0, Math.max(1, limit));
+}
+
+interface FeedbackStats {
+	accepted: number;
+	rejected: number;
+}
+
+function readFeedbackStats(): FeedbackStats {
+	if (typeof window === "undefined" || !window.localStorage) {
+		return { accepted: 0, rejected: 0 };
+	}
+
+	try {
+		const parsed = JSON.parse(window.localStorage.getItem(FEEDBACK_STORAGE_KEY) ?? "null") as FeedbackStats | null;
+		if (!parsed) return { accepted: 0, rejected: 0 };
+		return {
+			accepted: Number(parsed.accepted) || 0,
+			rejected: Number(parsed.rejected) || 0,
+		};
+	} catch {
+		return { accepted: 0, rejected: 0 };
+	}
+}
+
+function writeFeedbackStats(stats: FeedbackStats): void {
+	if (typeof window === "undefined" || !window.localStorage) return;
+	window.localStorage.setItem(FEEDBACK_STORAGE_KEY, JSON.stringify(stats));
+}
+
+export function trackEnergyMismatchFeedback(decision: FeedbackDecision): void {
+	const stats = readFeedbackStats();
+	if (decision === "accepted") {
+		stats.accepted += 1;
+	} else {
+		stats.rejected += 1;
+	}
+	writeFeedbackStats(stats);
+}
+
+export function getEnergyMismatchFeedbackStats(): {
+	accepted: number;
+	rejected: number;
+	total: number;
+	falsePositiveRate: number;
+} {
+	const stats = readFeedbackStats();
+	const total = stats.accepted + stats.rejected;
+	const falsePositiveRate = total === 0 ? 0 : stats.rejected / total;
+	return {
+		accepted: stats.accepted,
+		rejected: stats.rejected,
+		total,
+		falsePositiveRate,
+	};
+}
+
+export function __resetEnergyMismatchFeedbackForTests(): void {
+	if (typeof window === "undefined" || !window.localStorage) return;
+	window.localStorage.removeItem(FEEDBACK_STORAGE_KEY);
+}

--- a/src/utils/window-task-operations.ts
+++ b/src/utils/window-task-operations.ts
@@ -1,11 +1,37 @@
 import { invoke } from "@tauri-apps/api/core";
 import type { Task } from "@/types/task";
 import type { TaskOperation } from "@/components/m3/TaskOperations";
+import {
+	evaluateTaskEnergyMismatch,
+	rankAlternativeTasks,
+	type EnergyMismatchTaskLike,
+} from "@/utils/task-energy-mismatch";
 
 function dispatchTaskRefresh() {
 	if (typeof window === "undefined") return;
 	window.dispatchEvent(new CustomEvent("tasks:refresh"));
 }
+
+const toEnergyMismatchTask = (task: any): EnergyMismatchTaskLike => ({
+	id: String(task.id),
+	title: String(task.title ?? ""),
+	energy: (task.energy ?? "medium") as "low" | "medium" | "high",
+	requiredMinutes: task.requiredMinutes ?? task.required_minutes ?? 25,
+	priority: task.priority ?? 50,
+	state: task.state,
+	tags: Array.isArray(task.tags) ? task.tags : [],
+});
+
+const estimatePressureValue = (tasks: any[]): number => {
+	let pressure = 50;
+	const readyCount = tasks.filter((task) => task.state === "READY").length;
+	const doneCount = tasks.filter((task) => task.state === "DONE").length;
+	const runningCount = tasks.filter((task) => task.state === "RUNNING").length;
+	pressure += readyCount * 3;
+	pressure -= doneCount * 5;
+	if (runningCount > 0) pressure -= 10;
+	return Math.max(0, Math.min(100, Math.round(pressure)));
+};
 
 export async function runWindowTaskOperation(
 	task: Task | undefined,
@@ -18,6 +44,52 @@ export async function runWindowTaskOperation(
 			if (task.state === "PAUSED") {
 				await invoke("cmd_task_resume", { id: task.id });
 			} else {
+				const rawTasks = await invoke<any[]>("cmd_task_list");
+				const pressureValue = estimatePressureValue(rawTasks ?? []);
+				const target = toEnergyMismatchTask(task);
+				const mismatch = evaluateTaskEnergyMismatch(target, { pressureValue });
+				if (mismatch.shouldWarn) {
+					const alternatives = rankAlternativeTasks(
+						(rawTasks ?? []).map(toEnergyMismatchTask),
+						target.id,
+						{ pressureValue },
+						3,
+					).filter((candidate) => candidate.actionable);
+
+					await invoke("cmd_show_action_notification", {
+						notification: {
+							title: "エネルギーミスマッチ警告",
+							message: `${target.title} は現在の状態とミスマッチの可能性があります（${mismatch.score}/${mismatch.threshold}）。`,
+							buttons: [
+								{
+									label: "このまま開始",
+									action: {
+										start_task: {
+											id: target.id,
+											resume: false,
+											ignoreEnergyMismatch: true,
+											mismatchDecision: "accepted",
+										},
+									},
+								},
+								...alternatives.map((candidate) => ({
+									label: `代替: ${candidate.task.title}`,
+									action: {
+										start_task: {
+											id: candidate.task.id,
+											resume: false,
+											ignoreEnergyMismatch: false,
+											mismatchDecision: "rejected",
+										},
+									},
+								})),
+								{ label: "キャンセル", action: { dismiss: null } },
+							].slice(0, 5),
+						},
+					});
+					return;
+				}
+
 				await invoke("cmd_task_start", { id: task.id });
 			}
 			break;


### PR DESCRIPTION
## Summary\n- add task-energy mismatch scoring utility (energy + pressure + time-of-day + duration)\n- trigger pre-start warning only when mismatch score exceeds threshold\n- provide ranked actionable alternatives and short-segment hint\n- track accepted/rejected mismatch suggestions for false-positive monitoring\n- wire guard into action notification flow and detached-window direct start flow\n\n## Testing\n- npm run -s test -- src/utils/task-energy-mismatch.test.ts\n- npm run -s type-check\n- npm run -s check\n\nCloses #221