### PR TITLE
[Idea][Energy] Build low-energy fallback queue

### DIFF
--- a/docs/issues/222-idea-energy-build-low-energy-fallback-qu.md
+++ b/docs/issues/222-idea-energy-build-low-energy-fallback-qu.md
@@ -1,0 +1,23 @@
+# Issue #222
+
+- URL: https://github.com/rebuildup/pomodoroom/issues/222
+- Branch: issue-222-idea-energy-build-low-energy-fallback-qu
+
+## Implementation Plan
+- [x] Read issue + related files
+- [x] Add/adjust tests first
+- [x] Implement minimal solution
+- [x] Run checks
+- [ ] Open PR with Closes #222
+
+## Notes
+- Added `src/utils/low-energy-fallback-queue.ts` and tests (`src/utils/low-energy-fallback-queue.test.ts`).
+- Queue behavior:
+  - Builds dynamic fallback queue from READY/PAUSED eligible tasks.
+  - Non-empty whenever eligible tasks exist.
+  - Includes one-click start action payload generation (`createLowEnergyStartAction`).
+- Auto-suggestion trigger helper added (`shouldTriggerLowEnergySuggestion`) based on pressure/mismatch/capacity.
+- Feedback loop added (`recordLowEnergyQueueFeedback`) and used to improve ranking quality over time.
+- Integrated low-energy fallback suggestions into mismatch warning flow:
+  - `src/views/ActionNotificationView.tsx`
+  - `src/utils/window-task-operations.ts`

--- a/src/utils/low-energy-fallback-queue.test.ts
+++ b/src/utils/low-energy-fallback-queue.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+	__resetLowEnergyQueueFeedbackForTests,
+	buildLowEnergyFallbackQueue,
+	createLowEnergyStartAction,
+	recordLowEnergyQueueFeedback,
+	shouldTriggerLowEnergySuggestion,
+} from "./low-energy-fallback-queue";
+
+const baseTasks = [
+	{ id: "h1", title: "Deep work", energy: "high", requiredMinutes: 90, state: "READY", tags: ["deep"], priority: 60 },
+	{ id: "m1", title: "Docs", energy: "medium", requiredMinutes: 30, state: "READY", tags: ["docs"], priority: 50 },
+	{ id: "l1", title: "Inbox zero", energy: "low", requiredMinutes: 15, state: "READY", tags: ["quick"], priority: 40 },
+] as const;
+
+describe("low-energy-fallback-queue", () => {
+	beforeEach(() => {
+		__resetLowEnergyQueueFeedbackForTests();
+	});
+
+	it("keeps queue non-empty when eligible tasks exist", () => {
+		const queue = buildLowEnergyFallbackQueue(baseTasks, { pressureValue: 75 });
+		expect(queue.length).toBeGreaterThan(0);
+		expect(queue.some((entry) => entry.task.id === "l1")).toBe(true);
+	});
+
+	it("returns one-click start action for top suggestion", () => {
+		const queue = buildLowEnergyFallbackQueue(baseTasks, { pressureValue: 80 });
+		const action = createLowEnergyStartAction(queue[0]);
+		expect(action.start_task.id).toBe(queue[0]?.task.id);
+		expect(action.start_task.resume).toBe(false);
+	});
+
+	it("improves queue ordering from feedback loop", () => {
+		recordLowEnergyQueueFeedback("m1", "accepted");
+		recordLowEnergyQueueFeedback("m1", "accepted");
+		recordLowEnergyQueueFeedback("l1", "rejected");
+
+		const queue = buildLowEnergyFallbackQueue(baseTasks, { pressureValue: 70 });
+		expect(queue[0]?.task.id).toBe("m1");
+	});
+
+	it("triggers auto-suggestion when fatigue indicators spike", () => {
+		expect(shouldTriggerLowEnergySuggestion({ pressureValue: 82, mismatchScore: 70 })).toBe(true);
+		expect(shouldTriggerLowEnergySuggestion({ pressureValue: 35, mismatchScore: 20 })).toBe(false);
+	});
+});

--- a/src/utils/low-energy-fallback-queue.ts
+++ b/src/utils/low-energy-fallback-queue.ts
@@ -1,0 +1,146 @@
+import type { EnergyLevel } from "@/types/task";
+
+export interface LowEnergyTaskLike {
+	id: string;
+	title: string;
+	energy: EnergyLevel;
+	requiredMinutes?: number | null;
+	priority?: number | null;
+	state?: string;
+	tags?: readonly string[];
+}
+
+export interface LowEnergyQueueEntry {
+	task: LowEnergyTaskLike;
+	score: number;
+	reason: string;
+	actionable: boolean;
+}
+
+export interface LowEnergyQueueContext {
+	pressureValue: number;
+}
+
+export type LowEnergyStartAction = {
+	start_task: {
+		id: string;
+		resume: boolean;
+		ignoreEnergyMismatch: boolean;
+		mismatchDecision: "rejected";
+	};
+};
+
+const FEEDBACK_KEY = "low_energy_queue_feedback";
+
+function getRequiredMinutes(task: LowEnergyTaskLike): number {
+	const raw = task.requiredMinutes ?? 25;
+	return Number.isFinite(raw) ? Math.max(1, Math.round(raw)) : 25;
+}
+
+function isEligibleLowEnergyTask(task: LowEnergyTaskLike): boolean {
+	const tags = task.tags ?? [];
+	const requiredMinutes = getRequiredMinutes(task);
+	return (
+		task.energy === "low" ||
+		requiredMinutes <= 30 ||
+		tags.includes("quick") ||
+		tags.includes("admin") ||
+		tags.includes("recovery-mode") ||
+		tags.includes("light") ||
+		tags.includes("chore")
+	);
+}
+
+interface FeedbackRecord {
+	accepted: number;
+	rejected: number;
+}
+
+function readFeedbackMap(): Record<string, FeedbackRecord> {
+	if (typeof window === "undefined" || !window.localStorage) return {};
+	try {
+		const parsed = JSON.parse(window.localStorage.getItem(FEEDBACK_KEY) ?? "{}");
+		if (!parsed || typeof parsed !== "object") return {};
+		return parsed as Record<string, FeedbackRecord>;
+	} catch {
+		return {};
+	}
+}
+
+function writeFeedbackMap(map: Record<string, FeedbackRecord>): void {
+	if (typeof window === "undefined" || !window.localStorage) return;
+	window.localStorage.setItem(FEEDBACK_KEY, JSON.stringify(map));
+}
+
+export function recordLowEnergyQueueFeedback(taskId: string, decision: "accepted" | "rejected"): void {
+	const map = readFeedbackMap();
+	const current = map[taskId] ?? { accepted: 0, rejected: 0 };
+	if (decision === "accepted") current.accepted += 1;
+	else current.rejected += 1;
+	map[taskId] = current;
+	writeFeedbackMap(map);
+}
+
+export function buildLowEnergyFallbackQueue(
+	tasks: readonly LowEnergyTaskLike[],
+	context: LowEnergyQueueContext,
+	limit: number = 3,
+): LowEnergyQueueEntry[] {
+	const feedback = readFeedbackMap();
+	const candidates = tasks
+		.filter((task) => task.state === undefined || task.state === "READY" || task.state === "PAUSED")
+		.filter((task) => isEligibleLowEnergyTask(task))
+		.map((task) => {
+			const requiredMinutes = getRequiredMinutes(task);
+			const feedbackScore = (feedback[task.id]?.accepted ?? 0) * 16 - (feedback[task.id]?.rejected ?? 0) * 10;
+			const energyPenalty = task.energy === "low" ? 0 : task.energy === "medium" ? 15 : 40;
+			const durationPenalty = requiredMinutes <= 20 ? 0 : requiredMinutes <= 30 ? 8 : requiredMinutes <= 45 ? 20 : 35;
+			const pressurePenalty = context.pressureValue >= 70 ? (task.energy === "low" ? 0 : 15) : 0;
+			const priorityBonus = Math.max(-8, Math.min(8, Math.round(((task.priority ?? 50) - 50) / 6)));
+			const score = Math.max(
+				0,
+				Math.min(100, Math.round(100 - energyPenalty - durationPenalty - pressurePenalty + priorityBonus + feedbackScore)),
+			);
+			const reason = feedbackScore > 0
+				? "Preferred from past accepted low-energy suggestions"
+				: requiredMinutes <= 20
+					? "Short low-cognitive task"
+					: "Fits low-energy fallback context";
+			return {
+				task,
+				score,
+				reason,
+				actionable: true,
+			};
+		})
+		.sort((a, b) => b.score - a.score);
+
+	return candidates.slice(0, Math.max(1, limit));
+}
+
+export function createLowEnergyStartAction(entry: LowEnergyQueueEntry): LowEnergyStartAction {
+	return {
+		start_task: {
+			id: entry.task.id,
+			resume: entry.task.state === "PAUSED",
+			ignoreEnergyMismatch: false,
+			mismatchDecision: "rejected",
+		},
+	};
+}
+
+export function shouldTriggerLowEnergySuggestion(input: {
+	pressureValue: number;
+	mismatchScore?: number;
+	currentCapacity?: EnergyLevel;
+}): boolean {
+	if (input.currentCapacity === "low") return true;
+	if (input.pressureValue >= 70) return true;
+	if ((input.mismatchScore ?? 0) >= 65) return true;
+	return false;
+}
+
+export function __resetLowEnergyQueueFeedbackForTests(): void {
+	if (typeof window === "undefined" || !window.localStorage) return;
+	window.localStorage.removeItem(FEEDBACK_KEY);
+}


### PR DESCRIPTION
## Summary\n- add dynamic low-energy fallback queue utility with eligibility filtering and scoring\n- keep queue actionable via one-click start action payloads\n- add feedback loop for queue quality (accepted/rejected storage + ranking bonus)\n- auto-select low-energy queue suggestions when fatigue indicators spike\n- integrate queue suggestions into mismatch warning flows in action notification and detached window task operations\n\n## Testing\n- npm run -s test -- src/utils/low-energy-fallback-queue.test.ts\n- npm run -s type-check\n- npm run -s check\n\nCloses #222

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能
* 低エネルギー時のタスク提案機能を追加しました。ユーザーの疲労度や負荷に基づいて、適切なタスク候補を自動的に提案します。
* ユーザーのフィードバック（受け入れ/却下）を学習し、提案の精度を継続的に改善します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->