### PR TITLE
[Idea][Energy] Cognitive-load estimator from context switching

### DIFF
--- a/docs/issues/224-idea-energy-cognitive-load-estimator-fro.md
+++ b/docs/issues/224-idea-energy-cognitive-load-estimator-fro.md
@@ -1,0 +1,25 @@
+# Issue #224
+
+- URL: https://github.com/rebuildup/pomodoroom/issues/224
+- Branch: issue-224-idea-energy-cognitive-load-estimator-fro
+
+## Implementation Plan
+- [x] Read issue + related files
+- [x] Add/adjust tests first
+- [x] Implement minimal solution
+- [x] Run checks
+- [ ] Open PR with Closes #224
+
+## Notes
+- Added `src/utils/cognitive-load-estimator.ts` and tests (`src/utils/cognitive-load-estimator.test.ts`).
+- Implemented weighted cognitive-load index using:
+  - context switch rate,
+  - task/project heterogeneity,
+  - interruption rate.
+- Added daily stats helper with spike detection and adaptive break recommendation.
+- Wired estimator into scheduler-facing flow:
+  - `src/utils/auto-schedule-time.ts` now consumes cognitive load signal when recommending breaks.
+  - break tasks include cognitive signal tags (`cognitive-signal-*`, `cognitive-load-spike`).
+- Exposed index in daily stats UI:
+  - `src/views/StatsView.tsx` shows Cognitive Load and Recommended Break cards.
+- Added regression test to verify break recommendation increases on context-switch spikes.

--- a/src/utils/auto-schedule-time.test.ts
+++ b/src/utils/auto-schedule-time.test.ts
@@ -178,6 +178,50 @@ describe("buildProjectedTasksWithAutoBreaks", () => {
     expect((breaks[1]?.requiredMinutes ?? 0)).toBeGreaterThan(breaks[0]?.requiredMinutes ?? 0);
   });
 
+  it("increases break recommendation when context switching cognitive load spikes", () => {
+    const lowSwitchTasks = [
+      makeTask({
+        id: "low-1",
+        project: "A",
+        fixedStartAt: "2026-02-14T09:00:00.000Z",
+        requiredMinutes: 30,
+      }),
+      makeTask({
+        id: "low-2",
+        project: "A",
+        fixedStartAt: "2026-02-14T09:50:00.000Z",
+        requiredMinutes: 30,
+      }),
+    ];
+
+    const highSwitchTasks = [
+      makeTask({
+        id: "high-1",
+        project: "A",
+        tags: ["deep"],
+        fixedStartAt: "2026-02-14T09:00:00.000Z",
+        requiredMinutes: 30,
+      }),
+      makeTask({
+        id: "high-2",
+        project: "B",
+        tags: ["meeting"],
+        fixedStartAt: "2026-02-14T09:50:00.000Z",
+        requiredMinutes: 30,
+      }),
+    ];
+
+    const lowProjected = buildProjectedTasksWithAutoBreaks(lowSwitchTasks);
+    const highProjected = buildProjectedTasksWithAutoBreaks(highSwitchTasks);
+
+    const lowBreak = lowProjected.find((t) => t.kind === "break" && !t.tags.includes("auto-split-break"));
+    const highBreak = highProjected.find((t) => t.kind === "break" && !t.tags.includes("auto-split-break"));
+
+    expect(lowBreak?.requiredMinutes).toBeDefined();
+    expect(highBreak?.requiredMinutes).toBeDefined();
+    expect(highBreak?.requiredMinutes ?? 0).toBeGreaterThan(lowBreak?.requiredMinutes ?? 0);
+  });
+
   it("resets break ramp after a large gap", () => {
     const tasks = [
       makeTask({

--- a/src/utils/cognitive-load-estimator.test.ts
+++ b/src/utils/cognitive-load-estimator.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildDailyCognitiveLoadStats,
+	estimateCognitiveLoadIndex,
+	estimateCognitiveLoadFromTaskSequence,
+	getSchedulerCognitiveLoadSignal,
+	recommendBreakMinutesFromCognitiveLoad,
+} from "./cognitive-load-estimator";
+
+describe("cognitive-load-estimator", () => {
+	it("computes weighted switch index from switch frequency and heterogeneity", () => {
+		const low = estimateCognitiveLoadIndex([
+			{ completedAt: "2026-02-15T09:00:00.000Z", project: "A", task: "one", interrupted: false },
+			{ completedAt: "2026-02-15T09:30:00.000Z", project: "A", task: "two", interrupted: false },
+		]);
+		const high = estimateCognitiveLoadIndex([
+			{ completedAt: "2026-02-15T09:00:00.000Z", project: "A", task: "one", interrupted: true },
+			{ completedAt: "2026-02-15T09:20:00.000Z", project: "B", task: "two", interrupted: true },
+			{ completedAt: "2026-02-15T09:40:00.000Z", project: "C", task: "three", interrupted: true },
+		]);
+
+		expect(high.index).toBeGreaterThan(low.index);
+		expect(high.switchCount).toBeGreaterThan(0);
+	});
+
+	it("increases recommended break when index spikes", () => {
+		expect(recommendBreakMinutesFromCognitiveLoad(8, 20)).toBe(8);
+		expect(recommendBreakMinutesFromCognitiveLoad(8, 70)).toBeGreaterThan(8);
+		expect(recommendBreakMinutesFromCognitiveLoad(8, 90)).toBeGreaterThan(recommendBreakMinutesFromCognitiveLoad(8, 70));
+	});
+
+	it("builds daily stats payload with index and spike indicator", () => {
+		const stats = buildDailyCognitiveLoadStats(
+			[
+				{ completedAt: "2026-02-15T09:00:00.000Z", project: "A", task: "one", interrupted: true },
+				{ completedAt: "2026-02-15T09:20:00.000Z", project: "B", task: "two", interrupted: true },
+			],
+			new Date("2026-02-15T23:00:00.000Z"),
+		);
+
+		expect(stats.index).toBeGreaterThanOrEqual(0);
+		expect(stats.recommendedBreakMinutes).toBeGreaterThanOrEqual(5);
+		expect(typeof stats.spike).toBe("boolean");
+	});
+
+	it("provides scheduler-consumable normalized signal", () => {
+		const signal = getSchedulerCognitiveLoadSignal(80);
+		expect(signal).toBeGreaterThan(0.7);
+		expect(signal).toBeLessThanOrEqual(1);
+	});
+
+	it("estimates sequence cognitive load from planned task switches", () => {
+		const low = estimateCognitiveLoadFromTaskSequence([
+			{ project: "A", tags: ["deep"] },
+			{ project: "A", tags: ["deep"] },
+			{ project: "A", tags: ["deep"] },
+		]);
+		const high = estimateCognitiveLoadFromTaskSequence([
+			{ project: "A", tags: ["deep"] },
+			{ project: "B", tags: ["meeting"] },
+			{ project: "C", tags: ["admin"] },
+		]);
+
+		expect(high).toBeGreaterThan(low);
+	});
+});

--- a/src/utils/cognitive-load-estimator.ts
+++ b/src/utils/cognitive-load-estimator.ts
@@ -1,0 +1,138 @@
+export interface CognitiveLoadEvent {
+	completedAt?: string | Date;
+	project?: string | null;
+	task?: string | null;
+	tags?: readonly string[];
+	interrupted?: boolean;
+}
+
+export interface CognitiveLoadIndexResult {
+	index: number;
+	switchCount: number;
+	switchRate: number;
+	heterogeneity: number;
+	interruptionRate: number;
+}
+
+export interface DailyCognitiveLoadStats {
+	index: number;
+	switchCount: number;
+	recommendedBreakMinutes: number;
+	spike: boolean;
+}
+
+function clamp(value: number, min: number, max: number): number {
+	return Math.max(min, Math.min(max, value));
+}
+
+function toTimestamp(value: string | Date | undefined): number {
+	if (!value) return 0;
+	const d = value instanceof Date ? value : new Date(value);
+	return Number.isNaN(d.getTime()) ? 0 : d.getTime();
+}
+
+function getProjectKey(event: CognitiveLoadEvent): string {
+	const raw = (event.project ?? event.task ?? "none").toString().trim();
+	return raw.length > 0 ? raw.toLowerCase() : "none";
+}
+
+function normalizeTag(tag: string): string {
+	return tag.trim().toLowerCase();
+}
+
+export function estimateCognitiveLoadIndex(events: readonly CognitiveLoadEvent[]): CognitiveLoadIndexResult {
+	if (events.length <= 1) {
+		return {
+			index: 0,
+			switchCount: 0,
+			switchRate: 0,
+			heterogeneity: 0,
+			interruptionRate: events.length === 0 ? 0 : (events[0]?.interrupted ? 1 : 0),
+		};
+	}
+
+	const sorted = [...events].sort((a, b) => toTimestamp(a.completedAt) - toTimestamp(b.completedAt));
+	let switchCount = 0;
+	let prevProject = getProjectKey(sorted[0] ?? {});
+
+	const projectSet = new Set<string>();
+	const tagSet = new Set<string>();
+	let interruptedCount = 0;
+
+	for (const event of sorted) {
+		const project = getProjectKey(event);
+		projectSet.add(project);
+		for (const tag of event.tags ?? []) {
+			tagSet.add(normalizeTag(tag));
+		}
+		if (event.interrupted) interruptedCount += 1;
+
+		if (project !== prevProject) {
+			switchCount += 1;
+		}
+		prevProject = project;
+	}
+
+	const switchRate = switchCount / Math.max(1, sorted.length - 1);
+	const projectDiversity = clamp(projectSet.size / Math.max(1, Math.min(sorted.length, 4)), 0, 1);
+	const tagDiversity = clamp(tagSet.size / Math.max(1, Math.min(sorted.length * 2, 8)), 0, 1);
+	const heterogeneity = clamp(projectDiversity * 0.7 + tagDiversity * 0.3, 0, 1);
+	const interruptionRate = interruptedCount / Math.max(1, sorted.length);
+
+	const weighted = switchRate * 0.55 + heterogeneity * 0.3 + interruptionRate * 0.15;
+	const index = Math.round(clamp(weighted * 100, 0, 100));
+
+	return {
+		index,
+		switchCount,
+		switchRate,
+		heterogeneity,
+		interruptionRate,
+	};
+}
+
+export function estimateCognitiveLoadFromTaskSequence(
+	tasks: readonly { project?: string | null; tags?: readonly string[] }[],
+): number {
+	const pseudoEvents: CognitiveLoadEvent[] = tasks.map((task, idx) => ({
+		completedAt: new Date(1_700_000_000_000 + idx * 60_000).toISOString(),
+		project: task.project ?? null,
+		tags: task.tags ?? [],
+	}));
+	return estimateCognitiveLoadIndex(pseudoEvents).index;
+}
+
+export function isCognitiveLoadSpike(index: number): boolean {
+	return index >= 65;
+}
+
+export function recommendBreakMinutesFromCognitiveLoad(baseBreakMinutes: number, index: number): number {
+	if (index >= 85) return baseBreakMinutes + 6;
+	if (index >= 65) return baseBreakMinutes + 3;
+	return baseBreakMinutes;
+}
+
+export function getSchedulerCognitiveLoadSignal(index: number): number {
+	return clamp(index / 100, 0, 1);
+}
+
+export function buildDailyCognitiveLoadStats(
+	events: readonly CognitiveLoadEvent[],
+	date: Date = new Date(),
+): DailyCognitiveLoadStats {
+	const dateStr = date.toISOString().slice(0, 10);
+	const daily = events.filter((event) => {
+		const raw = event.completedAt;
+		if (!raw) return false;
+		const d = raw instanceof Date ? raw : new Date(raw);
+		if (Number.isNaN(d.getTime())) return false;
+		return d.toISOString().startsWith(dateStr);
+	});
+	const result = estimateCognitiveLoadIndex(daily);
+	return {
+		index: result.index,
+		switchCount: result.switchCount,
+		recommendedBreakMinutes: recommendBreakMinutesFromCognitiveLoad(5, result.index),
+		spike: isCognitiveLoadSpike(result.index),
+	};
+}

--- a/src/views/StatsView.tsx
+++ b/src/views/StatsView.tsx
@@ -17,6 +17,7 @@ import PomodoroChart from "@/components/charts/PomodoroChart";
 import ProjectPieChart from "@/components/charts/ProjectPieChart";
 import WeeklyHeatmap from "@/components/charts/WeeklyHeatmap";
 import { useTheme } from "@/hooks/useTheme";
+import { buildDailyCognitiveLoadStats } from "@/utils/cognitive-load-estimator";
 
 // Tab options
 type TabType = "today" | "week" | "month" | "projects" | "all";
@@ -345,6 +346,7 @@ export default function StatsView() {
 		);
 		const todayFocus = todaySessions.filter((s) => s.type === "focus" || s.type === "work");
 		const todayBreak = todaySessions.filter((s) => s.type !== "focus" && s.type !== "work");
+		const cognitiveLoadToday = buildDailyCognitiveLoadStats(todayFocus, now);
 
 		// Week
 		const weekSessions = sessions.filter((s) => {
@@ -440,6 +442,9 @@ export default function StatsView() {
 				focusTime: todayFocus.reduce((sum, s) => sum + s.duration, 0),
 				breakTime: todayBreak.reduce((sum, s) => sum + s.duration, 0),
 				pomodoros: todayFocus.length,
+				cognitiveLoadIndex: cognitiveLoadToday.index,
+				cognitiveLoadSpike: cognitiveLoadToday.spike,
+				recommendedBreakMinutes: cognitiveLoadToday.recommendedBreakMinutes,
 			},
 			week: {
 				sessions: weekSessions.length,
@@ -601,6 +606,25 @@ export default function StatsView() {
 								value={formatMinutes(localStats.today.breakTime)}
 								theme={theme}
 								color="orange"
+							/>
+						</div>
+
+						<div className="grid grid-cols-2 gap-3">
+							<StatCard
+								iconName="trending_up"
+								label="Cognitive Load"
+								value={localStats.today.cognitiveLoadIndex}
+								subValue={localStats.today.cognitiveLoadSpike ? "Spike detected" : "Stable"}
+								theme={theme}
+								color={localStats.today.cognitiveLoadSpike ? "orange" : "blue"}
+							/>
+							<StatCard
+								iconName="schedule"
+								label="Recommended Break"
+								value={`${localStats.today.recommendedBreakMinutes}m`}
+								subValue="Adaptive from context switching"
+								theme={theme}
+								color="green"
 							/>
 						</div>
 


### PR DESCRIPTION
## Summary
- add cognitive load estimator based on context-switch frequency and task heterogeneity
- expose daily cognitive load stats and spike-aware break recommendation helper
- feed estimator signal into auto-scheduler break recommendation path
- show cognitive load index and recommended break in Today stats
- add tests for estimator and scheduler reaction to cognitive-load spikes

## Testing
- npm run -s test -- src/utils/cognitive-load-estimator.test.ts src/utils/auto-schedule-time.test.ts
- npm run -s type-check
- npm run -s check

Closes #224
