### PR TITLE
[Idea][Notify] Context-aware nudge windows

### DIFF
--- a/docs/issues/225-idea-notify-context-aware-nudge-windows.md
+++ b/docs/issues/225-idea-notify-context-aware-nudge-windows.md
@@ -1,0 +1,26 @@
+# Issue #225
+
+- URL: https://github.com/rebuildup/pomodoroom/issues/225
+- Branch: issue-225-idea-notify-context-aware-nudge-windows
+
+## Implementation Plan
+- [x] Read issue + related files
+- [x] Add/adjust tests first
+- [x] Implement minimal solution
+- [x] Run checks
+- [ ] Open PR with Closes #225
+
+## Notes
+- Added `src/utils/nudge-window-policy.ts` and tests (`src/utils/nudge-window-policy.test.ts`).
+- Implemented nudge-safe window policy with configurable rules:
+  - suppress during active focus,
+  - defer duration,
+  - safe-hour window.
+- Added deferred nudge queue with safe replay (`enqueueDeferredNudge` / `dequeueReplayableNudge`).
+- Added nudge metrics tracking and acceptance-rate calculation.
+- Integrated policy at notification entrypoint in `src/hooks/useActionNotification.ts`:
+  - evaluate show/defer,
+  - auto-enqueue deferred nudges,
+  - replay deferred nudges safely when possible.
+- Integrated acceptance outcome tracking in `src/views/ActionNotificationView.tsx`.
+- Exposed configurable policy + visible metrics in `src/views/SettingsView.tsx`.

--- a/src/utils/nudge-window-policy.test.ts
+++ b/src/utils/nudge-window-policy.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+	__resetNudgePolicyForTests,
+	dequeueReplayableNudge,
+	enqueueDeferredNudge,
+	evaluateNudgeWindow,
+	getNudgeMetrics,
+	getNudgePolicyConfig,
+	recordNudgeOutcome,
+	setNudgePolicyConfig,
+} from "./nudge-window-policy";
+
+describe("nudge-window-policy", () => {
+	beforeEach(() => {
+		__resetNudgePolicyForTests();
+	});
+
+	it("applies configurable suppression rules", () => {
+		setNudgePolicyConfig({ suppressDuringRunningFocus: true, deferMinutes: 10 });
+		const decision = evaluateNudgeWindow(
+			{ title: "Nudge", message: "msg", buttons: [{ label: "Later", action: { dismiss: null } }] },
+			{ hasRunningFocus: true, now: new Date("2026-02-15T10:00:00.000Z") },
+			getNudgePolicyConfig(),
+		);
+		expect(decision).toBe("defer");
+	});
+
+	it("replays deferred nudges only after replay time and safe window", () => {
+		enqueueDeferredNudge(
+			{ title: "Deferred", message: "msg", buttons: [{ label: "ok", action: { dismiss: null } }] },
+			new Date("2026-02-15T10:00:00.000Z"),
+			5,
+		);
+
+		const tooEarly = dequeueReplayableNudge({ hasRunningFocus: false, now: new Date("2026-02-15T10:03:00.000Z") });
+		expect(tooEarly).toBeNull();
+
+		const replay = dequeueReplayableNudge({ hasRunningFocus: false, now: new Date("2026-02-15T10:07:00.000Z") });
+		expect(replay?.title).toBe("Deferred");
+	});
+
+	it("tracks acceptance metrics", () => {
+		recordNudgeOutcome("shown");
+		recordNudgeOutcome("shown");
+		recordNudgeOutcome("accepted");
+		recordNudgeOutcome("dismissed");
+		const metrics = getNudgeMetrics();
+		expect(metrics.shown).toBe(2);
+		expect(metrics.accepted).toBe(1);
+		expect(metrics.dismissed).toBe(1);
+		expect(metrics.acceptanceRate).toBeCloseTo(0.5, 4);
+	});
+});

--- a/src/utils/nudge-window-policy.ts
+++ b/src/utils/nudge-window-policy.ts
@@ -1,0 +1,187 @@
+export interface NudgePolicyConfig {
+	suppressDuringRunningFocus: boolean;
+	deferMinutes: number;
+	safeWindowStartHour: number;
+	safeWindowEndHour: number;
+}
+
+export interface NudgePolicyContext {
+	hasRunningFocus: boolean;
+	now: Date;
+}
+
+export interface NudgeNotification {
+	title: string;
+	message: string;
+	buttons: Array<{ label: string; action: Record<string, unknown> }>;
+}
+
+interface DeferredNudge {
+	notification: NudgeNotification;
+	replayAfterIso: string;
+	queuedAtIso: string;
+}
+
+interface NudgeMetrics {
+	shown: number;
+	deferred: number;
+	replayed: number;
+	accepted: number;
+	dismissed: number;
+}
+
+const CONFIG_KEY = "nudge_policy_config";
+const QUEUE_KEY = "nudge_deferred_queue";
+const METRICS_KEY = "nudge_policy_metrics";
+
+const DEFAULT_CONFIG: NudgePolicyConfig = {
+	suppressDuringRunningFocus: true,
+	deferMinutes: 8,
+	safeWindowStartHour: 8,
+	safeWindowEndHour: 22,
+};
+
+const DEFAULT_METRICS: NudgeMetrics = {
+	shown: 0,
+	deferred: 0,
+	replayed: 0,
+	accepted: 0,
+	dismissed: 0,
+};
+
+function clamp(value: number, min: number, max: number): number {
+	return Math.max(min, Math.min(max, value));
+}
+
+function readJson<T>(key: string, fallback: T): T {
+	if (typeof window === "undefined" || !window.localStorage) return fallback;
+	try {
+		const raw = window.localStorage.getItem(key);
+		if (!raw) return fallback;
+		return JSON.parse(raw) as T;
+	} catch {
+		return fallback;
+	}
+}
+
+function writeJson(key: string, value: unknown): void {
+	if (typeof window === "undefined" || !window.localStorage) return;
+	window.localStorage.setItem(key, JSON.stringify(value));
+}
+
+function isUrgentNotification(notification: NudgeNotification): boolean {
+	const text = `${notification.title} ${notification.message}`.toLowerCase();
+	if (text.includes("critical") || text.includes("緊急") || text.includes("overload")) return true;
+	return notification.buttons.some((button) => {
+		const keys = Object.keys(button.action);
+		return keys.some((key) => key === "complete" || key === "pause" || key === "interrupt_task");
+	});
+}
+
+export function getNudgePolicyConfig(): NudgePolicyConfig {
+	const raw = readJson<Partial<NudgePolicyConfig>>(CONFIG_KEY, DEFAULT_CONFIG);
+	return {
+		suppressDuringRunningFocus: raw.suppressDuringRunningFocus ?? DEFAULT_CONFIG.suppressDuringRunningFocus,
+		deferMinutes: clamp(raw.deferMinutes ?? DEFAULT_CONFIG.deferMinutes, 1, 60),
+		safeWindowStartHour: clamp(raw.safeWindowStartHour ?? DEFAULT_CONFIG.safeWindowStartHour, 0, 23),
+		safeWindowEndHour: clamp(raw.safeWindowEndHour ?? DEFAULT_CONFIG.safeWindowEndHour, 0, 23),
+	};
+}
+
+export function setNudgePolicyConfig(next: Partial<NudgePolicyConfig>): NudgePolicyConfig {
+	const merged = { ...getNudgePolicyConfig(), ...next };
+	writeJson(CONFIG_KEY, merged);
+	return getNudgePolicyConfig();
+}
+
+function isWithinSafeWindow(now: Date, config: NudgePolicyConfig): boolean {
+	const hour = now.getHours();
+	if (config.safeWindowStartHour <= config.safeWindowEndHour) {
+		return hour >= config.safeWindowStartHour && hour < config.safeWindowEndHour;
+	}
+	return hour >= config.safeWindowStartHour || hour < config.safeWindowEndHour;
+}
+
+export function evaluateNudgeWindow(
+	notification: NudgeNotification,
+	context: NudgePolicyContext,
+	config: NudgePolicyConfig,
+): "show" | "defer" {
+	if (isUrgentNotification(notification)) return "show";
+	if (config.suppressDuringRunningFocus && context.hasRunningFocus) return "defer";
+	if (!isWithinSafeWindow(context.now, config)) return "defer";
+	return "show";
+}
+
+function getQueue(): DeferredNudge[] {
+	const queue = readJson<DeferredNudge[]>(QUEUE_KEY, []);
+	return Array.isArray(queue) ? queue : [];
+}
+
+function setQueue(queue: DeferredNudge[]): void {
+	writeJson(QUEUE_KEY, queue.slice(-100));
+}
+
+export function enqueueDeferredNudge(
+	notification: NudgeNotification,
+	now: Date,
+	deferMinutes: number,
+): void {
+	const queue = getQueue();
+	queue.push({
+		notification,
+		queuedAtIso: now.toISOString(),
+		replayAfterIso: new Date(now.getTime() + deferMinutes * 60_000).toISOString(),
+	});
+	setQueue(queue);
+	recordNudgeOutcome("deferred");
+}
+
+export function dequeueReplayableNudge(context: NudgePolicyContext): NudgeNotification | null {
+	if (context.hasRunningFocus) return null;
+	const queue = getQueue();
+	if (queue.length === 0) return null;
+	const nowMs = context.now.getTime();
+	for (let i = 0; i < queue.length; i++) {
+		const item = queue[i];
+		if (!item) continue;
+		const replayAt = Date.parse(item.replayAfterIso);
+		if (!Number.isNaN(replayAt) && replayAt <= nowMs) {
+			queue.splice(i, 1);
+			setQueue(queue);
+			recordNudgeOutcome("replayed");
+			return item.notification;
+		}
+	}
+	return null;
+}
+
+export function recordNudgeOutcome(
+	type: keyof NudgeMetrics,
+): void {
+	const current = readJson<NudgeMetrics>(METRICS_KEY, DEFAULT_METRICS);
+	const next: NudgeMetrics = {
+		...DEFAULT_METRICS,
+		...current,
+		[type]: (current[type] ?? 0) + 1,
+	};
+	writeJson(METRICS_KEY, next);
+}
+
+export function getNudgeMetrics(): NudgeMetrics & { acceptanceRate: number } {
+	const metrics = readJson<NudgeMetrics>(METRICS_KEY, DEFAULT_METRICS);
+	const denominator = (metrics.accepted ?? 0) + (metrics.dismissed ?? 0);
+	return {
+		...DEFAULT_METRICS,
+		...metrics,
+		acceptanceRate: denominator === 0 ? 0 : (metrics.accepted ?? 0) / denominator,
+	};
+}
+
+export function __resetNudgePolicyForTests(): void {
+	if (typeof window !== "undefined" && window.localStorage) {
+		window.localStorage.removeItem(CONFIG_KEY);
+		window.localStorage.removeItem(QUEUE_KEY);
+		window.localStorage.removeItem(METRICS_KEY);
+	}
+}

--- a/src/views/ActionNotificationView.tsx
+++ b/src/views/ActionNotificationView.tsx
@@ -25,6 +25,7 @@ import {
 	recordLowEnergyQueueFeedback,
 	shouldTriggerLowEnergySuggestion,
 } from "@/utils/low-energy-fallback-queue";
+import { recordNudgeOutcome } from "@/utils/nudge-window-policy";
 
 // Defer reason templates for postponement tracking
 export const DEFER_REASON_TEMPLATES = [
@@ -409,6 +410,7 @@ export function ActionNotificationView() {
 					resume_at: action.interrupt_task.resume_at,
 				});
 			} else if ('dismiss' in action) {
+				recordNudgeOutcome("dismissed");
 				// Always close even if clear fails
 				try {
 					await invoke("cmd_clear_action_notification");
@@ -418,6 +420,8 @@ export function ActionNotificationView() {
 				await closeSelf();
 				return;
 			}
+
+			recordNudgeOutcome("accepted");
 
 			try {
 				await invoke("cmd_clear_action_notification");

--- a/src/views/SettingsView.tsx
+++ b/src/views/SettingsView.tsx
@@ -33,6 +33,11 @@ import {
 	getPressureThresholdHistory,
 	resetPressureThresholdCalibration,
 } from "@/utils/pressure-threshold-calibration";
+import {
+	getNudgeMetrics,
+	getNudgePolicyConfig,
+	setNudgePolicyConfig,
+} from "@/utils/nudge-window-policy";
 
 export interface SettingsViewProps {
 	/** Window label - if provided, render as standalone window with TitleBar */
@@ -52,6 +57,8 @@ export default function SettingsView({ windowLabel }: SettingsViewProps = {}) {
 	const [settings, setSettings] = useConfig();
 	const [pressureCalibration, setPressureCalibration] = useState(getPressureThresholdCalibration);
 	const [pressureHistoryCount, setPressureHistoryCount] = useState(() => getPressureThresholdHistory().length);
+	const [nudgePolicy, setNudgePolicy] = useState(getNudgePolicyConfig);
+	const [nudgeMetrics, setNudgeMetrics] = useState(getNudgeMetrics);
 	const theme = settings.theme;
 	const highlightColor = settings.highlightColor ?? DEFAULT_HIGHLIGHT_COLOR;
 
@@ -75,6 +82,8 @@ export default function SettingsView({ windowLabel }: SettingsViewProps = {}) {
 	useEffect(() => {
 		setPressureCalibration(getPressureThresholdCalibration());
 		setPressureHistoryCount(getPressureThresholdHistory().length);
+		setNudgePolicy(getNudgePolicyConfig());
+		setNudgeMetrics(getNudgeMetrics());
 	}, []);
 
 	const content = (
@@ -272,6 +281,50 @@ export default function SettingsView({ windowLabel }: SettingsViewProps = {}) {
 								}}
 							>
 								デフォルトにリセット
+							</Button>
+						</div>
+					</section>
+
+					{/* ─── Nudge Policy ───────────────── */}
+					<section>
+						<h3 className="text-xs font-bold uppercase tracking-widest mb-4 text-[var(--md-ref-color-on-surface-variant)]">
+							通知ナッジポリシー
+						</h3>
+						<div className="space-y-4">
+							<ToggleRow
+								label="集中中は非緊急ナッジを延期"
+								value={nudgePolicy.suppressDuringRunningFocus}
+								onChange={() => {
+									const next = setNudgePolicyConfig({
+										suppressDuringRunningFocus: !nudgePolicy.suppressDuringRunningFocus,
+									});
+									setNudgePolicy(next);
+								}}
+							/>
+							<Slider
+								min={1}
+								max={30}
+								step={1}
+								value={nudgePolicy.deferMinutes}
+								onChange={(v) => {
+									const next = setNudgePolicyConfig({ deferMinutes: v });
+									setNudgePolicy(next);
+								}}
+								label={<span>延期時間</span>}
+								valueLabel={<span>{nudgePolicy.deferMinutes}分</span>}
+							/>
+							<div className="text-sm text-[var(--md-ref-color-on-surface)] space-y-1">
+								<div>表示: {nudgeMetrics.shown}</div>
+								<div>延期: {nudgeMetrics.deferred}</div>
+								<div>再生: {nudgeMetrics.replayed}</div>
+								<div>受諾率: {(nudgeMetrics.acceptanceRate * 100).toFixed(1)}%</div>
+							</div>
+							<Button
+								variant="tonal"
+								size="small"
+								onClick={() => setNudgeMetrics(getNudgeMetrics())}
+							>
+								メトリクス更新
 							</Button>
 						</div>
 					</section>


### PR DESCRIPTION
## Summary
- add configurable context-aware nudge window policy (safe window + running focus suppression)
- defer non-urgent nudges automatically and replay deferred nudges safely
- track nudge outcomes and acceptance rate metrics
- apply policy in action-notification entrypoint for centralized behavior
- surface nudge policy settings and metrics in Settings

## Testing
- npm run -s test -- src/utils/nudge-window-policy.test.ts
- npm run -s type-check
- npm run -s check

Closes #225


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * スマート通知管理機能を追加しました。フォーカス中の通知を自動延期し、安全な時間帯に自動再表示します。設定画面で通知の遅延時間を調整でき、受信率などの統計情報が確認できるようになりました。

* **Tests**
  * 通知ポリシーの動作検証テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->