### PR TITLE
feat: break activity suggestion cards in notifications

### DIFF
--- a/docs/issues/226-idea-notify-break-activity-suggestion-ca.md
+++ b/docs/issues/226-idea-notify-break-activity-suggestion-ca.md
@@ -1,0 +1,23 @@
+﻿# Issue #226
+
+- URL: https://github.com/rebuildup/pomodoroom/issues/226
+- Branch: issue-226-idea-notify-break-activity-suggestion-ca
+
+## Implementation Plan
+- [x] Read issue + related files
+- [x] Add/adjust tests first
+- [x] Implement minimal solution
+- [x] Run checks
+- [ ] Open PR with Closes #226
+
+## Notes
+- Added `src/utils/break-activity-catalog.ts` with editable local catalog, suggestion ranking,
+  pinning, feedback scoring, and rotation by context (break minutes + fatigue).
+- Added `src/utils/break-activity-catalog.test.ts` for catalog editability, pin boost,
+  non-repetition rotation, and feedback-based ranking.
+- `ActionNotificationView` now renders break activity suggestion cards for break-context
+  notifications and records selection feedback.
+- `useTauriTimer` break completion notifications now include minute context in message so
+  5/10/15/30 mapping can be applied.
+- `SettingsView` now includes break activity catalog management (upsert/edit, pin, enable/disable).
+

--- a/src/hooks/useTauriTimer.ts
+++ b/src/hooks/useTauriTimer.ts
@@ -245,9 +245,14 @@ export function useTauriTimer() {
 					if (showActionNotification) {
 						try {
 							const stepType = snap.step_type === "focus" ? "集中" : "休憩";
+							const stepMinutes = Math.max(1, Math.round((snap.total_ms ?? 0) / 60_000));
+							const detailMessage =
+								snap.step_type === "break"
+									? `${stepMinutes}分休憩です。次の行動をお選びください`
+									: "お疲れ様でした！次の行動をお選びください";
 							await showActionNotification({
 								title: `${stepType}完了！`,
-								message: "お疲れ様でした！次の行動をお選びください",
+								message: detailMessage,
 								buttons: [
 									{ label: "完了", action: { complete: null } },
 									{ label: "+25分", action: { extend: { minutes: 25 } } },

--- a/src/utils/break-activity-catalog.test.ts
+++ b/src/utils/break-activity-catalog.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+	__resetBreakActivityCatalogForTests,
+	getBreakActivityCatalog,
+	getBreakActivitySuggestions,
+	recordBreakActivityFeedback,
+	togglePinBreakActivity,
+	upsertBreakActivity,
+} from "./break-activity-catalog";
+
+describe("break-activity-catalog", () => {
+	beforeEach(() => {
+		__resetBreakActivityCatalogForTests();
+	});
+
+	it("provides editable catalog entries", () => {
+		const created = upsertBreakActivity({
+			id: "custom-breath",
+			title: "4-7-8 Breathing",
+			description: "Slow breathing cycle",
+			durationBucket: 5,
+			tags: ["mindful"],
+		});
+
+		expect(created.title).toBe("4-7-8 Breathing");
+		expect(getBreakActivityCatalog().some((item) => item.id === "custom-breath")).toBe(true);
+	});
+
+	it("ranks pinned preferences higher", () => {
+		togglePinBreakActivity("walk-quick", true);
+		const suggestions = getBreakActivitySuggestions({ breakMinutes: 5, fatigueLevel: "high", limit: 3 });
+		expect(suggestions[0]?.id).toBe("walk-quick");
+	});
+
+	it("rotates suggestions to avoid immediate repetition", () => {
+		const first = getBreakActivitySuggestions({ breakMinutes: 10, fatigueLevel: "medium", limit: 2 });
+		const second = getBreakActivitySuggestions({ breakMinutes: 10, fatigueLevel: "medium", limit: 2 });
+		expect(second[0]?.id).not.toBe(first[0]?.id);
+	});
+
+	it("preference feedback improves ranking", () => {
+		recordBreakActivityFeedback("hydration", "selected");
+		recordBreakActivityFeedback("hydration", "selected");
+		const suggestions = getBreakActivitySuggestions({ breakMinutes: 5, fatigueLevel: "high", limit: 3 });
+		expect(suggestions.some((item) => item.id === "hydration")).toBe(true);
+	});
+});

--- a/src/utils/break-activity-catalog.ts
+++ b/src/utils/break-activity-catalog.ts
@@ -1,0 +1,315 @@
+export type BreakFatigueLevel = "low" | "medium" | "high";
+
+export interface BreakActivity {
+	id: string;
+	title: string;
+	description: string;
+	durationBucket: number;
+	tags: string[];
+	enabled: boolean;
+	pinned: boolean;
+	usageCount: number;
+	selectedCount: number;
+	dismissedCount: number;
+	lastSelectedAt?: string;
+}
+
+export interface BreakActivitySuggestionOptions {
+	breakMinutes: number;
+	fatigueLevel: BreakFatigueLevel;
+	limit?: number;
+}
+
+interface BreakActivityInput {
+	id: string;
+	title: string;
+	description: string;
+	durationBucket: number;
+	tags: string[];
+	enabled?: boolean;
+}
+
+type BreakActivityFeedback = "selected" | "dismissed";
+
+const STORAGE_KEY = "break_activity_catalog_v1";
+const LAST_TOP_KEY = "break_activity_last_top_v1";
+
+const DEFAULT_CATALOG: BreakActivity[] = [
+	{
+		id: "hydration",
+		title: "水分補給",
+		description: "コップ一杯の水を飲む",
+		durationBucket: 5,
+		tags: ["recovery", "high-fatigue"],
+		enabled: true,
+		pinned: false,
+		usageCount: 0,
+		selectedCount: 0,
+		dismissedCount: 0,
+	},
+	{
+		id: "walk-quick",
+		title: "クイック散歩",
+		description: "室内または屋外を軽く歩く",
+		durationBucket: 5,
+		tags: ["movement", "medium-fatigue", "high-fatigue"],
+		enabled: true,
+		pinned: false,
+		usageCount: 0,
+		selectedCount: 0,
+		dismissedCount: 0,
+	},
+	{
+		id: "stretch-upper",
+		title: "上半身ストレッチ",
+		description: "首と肩を中心にゆっくり伸ばす",
+		durationBucket: 10,
+		tags: ["movement", "high-fatigue"],
+		enabled: true,
+		pinned: false,
+		usageCount: 0,
+		selectedCount: 0,
+		dismissedCount: 0,
+	},
+	{
+		id: "breathing-reset",
+		title: "呼吸リセット",
+		description: "4-4-6 の深呼吸を5セット",
+		durationBucket: 5,
+		tags: ["mindful", "high-fatigue"],
+		enabled: true,
+		pinned: false,
+		usageCount: 0,
+		selectedCount: 0,
+		dismissedCount: 0,
+	},
+	{
+		id: "desk-tidy",
+		title: "デスク整理",
+		description: "机の上を片付けて視界を整える",
+		durationBucket: 10,
+		tags: ["reset", "low-fatigue", "medium-fatigue"],
+		enabled: true,
+		pinned: false,
+		usageCount: 0,
+		selectedCount: 0,
+		dismissedCount: 0,
+	},
+	{
+		id: "eye-rest",
+		title: "目の休憩",
+		description: "20-20-20ルールで視線を遠くに移す",
+		durationBucket: 5,
+		tags: ["recovery", "high-fatigue"],
+		enabled: true,
+		pinned: false,
+		usageCount: 0,
+		selectedCount: 0,
+		dismissedCount: 0,
+	},
+	{
+		id: "mobility-flow",
+		title: "全身モビリティ",
+		description: "腰・背中・脚を順番に動かす",
+		durationBucket: 15,
+		tags: ["movement", "medium-fatigue"],
+		enabled: true,
+		pinned: false,
+		usageCount: 0,
+		selectedCount: 0,
+		dismissedCount: 0,
+	},
+	{
+		id: "micro-nap",
+		title: "マイクロ仮眠",
+		description: "目を閉じて静かに休む",
+		durationBucket: 30,
+		tags: ["recovery", "high-fatigue"],
+		enabled: true,
+		pinned: false,
+		usageCount: 0,
+		selectedCount: 0,
+		dismissedCount: 0,
+	},
+];
+
+function readJson<T>(key: string, fallback: T): T {
+	if (typeof window === "undefined" || !window.localStorage) return fallback;
+	try {
+		const raw = window.localStorage.getItem(key);
+		if (!raw) return fallback;
+		return JSON.parse(raw) as T;
+	} catch {
+		return fallback;
+	}
+}
+
+function writeJson(key: string, value: unknown): void {
+	if (typeof window === "undefined" || !window.localStorage) return;
+	window.localStorage.setItem(key, JSON.stringify(value));
+}
+
+function contextKey(options: BreakActivitySuggestionOptions): string {
+	return `${options.breakMinutes}:${options.fatigueLevel}`;
+}
+
+function normalizeBucket(minutes: number): number {
+	if (minutes <= 5) return 5;
+	if (minutes <= 10) return 10;
+	if (minutes <= 15) return 15;
+	return 30;
+}
+
+function getCatalog(): BreakActivity[] {
+	const catalog = readJson<BreakActivity[]>(STORAGE_KEY, DEFAULT_CATALOG);
+	if (!Array.isArray(catalog) || catalog.length === 0) {
+		writeJson(STORAGE_KEY, DEFAULT_CATALOG);
+		return [...DEFAULT_CATALOG];
+	}
+	return catalog.map((item) => ({
+		...item,
+		enabled: item.enabled ?? true,
+		pinned: item.pinned ?? false,
+		usageCount: item.usageCount ?? 0,
+		selectedCount: item.selectedCount ?? 0,
+		dismissedCount: item.dismissedCount ?? 0,
+		tags: Array.isArray(item.tags) ? item.tags : [],
+	}));
+}
+
+function saveCatalog(catalog: BreakActivity[]): void {
+	writeJson(STORAGE_KEY, catalog);
+}
+
+function scoreActivity(
+	item: BreakActivity,
+	options: BreakActivitySuggestionOptions,
+): number {
+	const bucket = normalizeBucket(options.breakMinutes);
+	const fatigueTag = `${options.fatigueLevel}-fatigue`;
+	let score = 0;
+	score += Math.max(0, 30 - Math.abs(item.durationBucket - bucket) * 3);
+	score += item.pinned ? 100 : 0;
+	score += item.selectedCount * 12;
+	score -= item.dismissedCount * 4;
+	score -= item.usageCount * 2;
+	score += item.tags.includes(fatigueTag) ? 24 : 0;
+	score += item.tags.includes("recovery") && options.fatigueLevel === "high" ? 10 : 0;
+	score += item.tags.includes("movement") && options.fatigueLevel !== "high" ? 6 : 0;
+	return score;
+}
+
+export function getBreakActivityCatalog(): BreakActivity[] {
+	return getCatalog().sort((a, b) => {
+		if (a.pinned !== b.pinned) return a.pinned ? -1 : 1;
+		return a.title.localeCompare(b.title, "ja");
+	});
+}
+
+export function upsertBreakActivity(input: BreakActivityInput): BreakActivity {
+	const catalog = getCatalog();
+	const index = catalog.findIndex((item) => item.id === input.id);
+	if (index >= 0) {
+		const updated: BreakActivity = {
+			...catalog[index],
+			title: input.title,
+			description: input.description,
+			durationBucket: normalizeBucket(input.durationBucket),
+			tags: [...new Set(input.tags)],
+			enabled: input.enabled ?? catalog[index].enabled,
+		};
+		catalog[index] = updated;
+		saveCatalog(catalog);
+		return updated;
+	}
+	const created: BreakActivity = {
+		id: input.id,
+		title: input.title,
+		description: input.description,
+		durationBucket: normalizeBucket(input.durationBucket),
+		tags: [...new Set(input.tags)],
+		enabled: input.enabled ?? true,
+		pinned: false,
+		usageCount: 0,
+		selectedCount: 0,
+		dismissedCount: 0,
+	};
+	catalog.push(created);
+	saveCatalog(catalog);
+	return created;
+}
+
+export function setBreakActivityEnabled(id: string, enabled: boolean): BreakActivity | null {
+	const catalog = getCatalog();
+	const index = catalog.findIndex((item) => item.id === id);
+	if (index < 0) return null;
+	const next = { ...catalog[index], enabled };
+	catalog[index] = next;
+	saveCatalog(catalog);
+	return next;
+}
+
+export function togglePinBreakActivity(id: string, pinned?: boolean): BreakActivity | null {
+	const catalog = getCatalog();
+	const index = catalog.findIndex((item) => item.id === id);
+	if (index < 0) return null;
+	const nextPinned = pinned ?? !catalog[index].pinned;
+	const next = { ...catalog[index], pinned: nextPinned };
+	catalog[index] = next;
+	saveCatalog(catalog);
+	return next;
+}
+
+export function recordBreakActivityFeedback(
+	id: string,
+	feedback: BreakActivityFeedback,
+): BreakActivity | null {
+	const catalog = getCatalog();
+	const index = catalog.findIndex((item) => item.id === id);
+	if (index < 0) return null;
+	const current = catalog[index];
+	const next: BreakActivity = {
+		...current,
+		usageCount: current.usageCount + 1,
+		selectedCount: feedback === "selected" ? current.selectedCount + 1 : current.selectedCount,
+		dismissedCount: feedback === "dismissed" ? current.dismissedCount + 1 : current.dismissedCount,
+		lastSelectedAt: feedback === "selected" ? new Date().toISOString() : current.lastSelectedAt,
+	};
+	catalog[index] = next;
+	saveCatalog(catalog);
+	return next;
+}
+
+export function getBreakActivitySuggestions(
+	options: BreakActivitySuggestionOptions,
+): BreakActivity[] {
+	const catalog = getCatalog().filter((item) => item.enabled);
+	const ranked = catalog
+		.map((item) => ({ item, score: scoreActivity(item, options) }))
+		.sort((a, b) => b.score - a.score || a.item.title.localeCompare(b.item.title, "ja"));
+
+	if (ranked.length === 0) return [];
+
+	const key = contextKey(options);
+	const lastTopByContext = readJson<Record<string, string>>(LAST_TOP_KEY, {});
+	const lastTop = lastTopByContext[key];
+	if (ranked.length > 1 && ranked[0]?.item.id === lastTop) {
+		const first = ranked.shift();
+		if (first) ranked.push(first);
+	}
+
+	const limit = Math.max(1, options.limit ?? 3);
+	const selected = ranked.slice(0, limit).map(({ item }) => item);
+	if (selected[0]) {
+		lastTopByContext[key] = selected[0].id;
+		writeJson(LAST_TOP_KEY, lastTopByContext);
+	}
+	return selected;
+}
+
+export function __resetBreakActivityCatalogForTests(): void {
+	if (typeof window !== "undefined" && window.localStorage) {
+		window.localStorage.removeItem(STORAGE_KEY);
+		window.localStorage.removeItem(LAST_TOP_KEY);
+	}
+}

--- a/src/views/ActionNotificationView.tsx
+++ b/src/views/ActionNotificationView.tsx
@@ -26,6 +26,12 @@ import {
 	shouldTriggerLowEnergySuggestion,
 } from "@/utils/low-energy-fallback-queue";
 import { recordNudgeOutcome } from "@/utils/nudge-window-policy";
+import {
+	getBreakActivitySuggestions,
+	recordBreakActivityFeedback,
+	type BreakActivity,
+	type BreakFatigueLevel,
+} from "@/utils/break-activity-catalog";
 
 // Defer reason templates for postponement tracking
 export const DEFER_REASON_TEMPLATES = [
@@ -119,6 +125,21 @@ interface ActionNotificationData {
 	buttons: NotificationButton[];
 }
 
+function parseBreakMinutes(notification: ActionNotificationData): number {
+	const text = `${notification.title} ${notification.message}`;
+	const match = text.match(/(\d+)\s*分/);
+	if (match?.[1]) {
+		const parsed = Number.parseInt(match[1], 10);
+		if (!Number.isNaN(parsed)) return parsed;
+	}
+	return 5;
+}
+
+function isBreakNotification(notification: ActionNotificationData): boolean {
+	const text = `${notification.title} ${notification.message}`.toLowerCase();
+	return text.includes("休憩") || text.includes("break");
+}
+
 function getStartIso(task: any): string | null {
 	const fixed = task.fixedStartAt ?? task.fixed_start_at ?? null;
 	const windowStart = task.windowStartAt ?? task.window_start_at ?? null;
@@ -129,6 +150,11 @@ function getStartIso(task: any): string | null {
 export function ActionNotificationView() {
 	const [notification, setNotification] = useState<ActionNotificationData | null>(null);
 	const [isProcessing, setIsProcessing] = useState(false);
+	const [breakSuggestions, setBreakSuggestions] = useState<BreakActivity[]>([]);
+	const [breakSuggestionContext, setBreakSuggestionContext] = useState<{
+		breakMinutes: number;
+		fatigueLevel: BreakFatigueLevel;
+	} | null>(null);
 	const [deferReasonStep, setDeferReasonStep] = useState<{
 		taskId: string;
 		taskTitle: string;
@@ -167,6 +193,45 @@ export function ActionNotificationView() {
 
 		loadNotification();
 	}, []);
+
+	useEffect(() => {
+		const loadBreakSuggestions = async () => {
+			if (!notification || !isBreakNotification(notification)) {
+				setBreakSuggestions([]);
+				setBreakSuggestionContext(null);
+				return;
+			}
+			const breakMinutes = parseBreakMinutes(notification);
+			let fatigueLevel: BreakFatigueLevel = "medium";
+			try {
+				const tasks = await invoke<any[]>("cmd_task_list");
+				const pressure = estimatePressureValue(tasks ?? []);
+				if (pressure >= 70) fatigueLevel = "high";
+				else if (pressure <= 35) fatigueLevel = "low";
+			} catch {
+				fatigueLevel = "medium";
+			}
+			const suggestions = getBreakActivitySuggestions({
+				breakMinutes,
+				fatigueLevel,
+				limit: 3,
+			});
+			setBreakSuggestionContext({ breakMinutes, fatigueLevel });
+			setBreakSuggestions(suggestions);
+		};
+		void loadBreakSuggestions();
+	}, [notification]);
+
+	const handleBreakSuggestionSelect = (activityId: string) => {
+		recordBreakActivityFeedback(activityId, "selected");
+		if (!breakSuggestionContext) return;
+		const suggestions = getBreakActivitySuggestions({
+			breakMinutes: breakSuggestionContext.breakMinutes,
+			fatigueLevel: breakSuggestionContext.fatigueLevel,
+			limit: 3,
+		});
+		setBreakSuggestions(suggestions);
+	};
 
 	// Handle button click
 	const handleAction = async (button: NotificationButton) => {
@@ -460,6 +525,38 @@ export function ActionNotificationView() {
 					</p>
 				</div>
 			</div>
+
+			{breakSuggestions.length > 0 && (
+				<div className="rounded-lg border border-[var(--md-ref-color-outline-variant)] p-2 space-y-2">
+					<div className="text-[11px] font-medium text-[var(--md-ref-color-on-surface-variant)]">
+						休憩アクティビティ提案
+					</div>
+					<div className="space-y-1">
+						{breakSuggestions.map((activity) => (
+							<div
+								key={activity.id}
+								className="flex items-center justify-between gap-2 rounded-md bg-[var(--md-ref-color-surface-container)] px-2 py-1"
+							>
+								<div className="min-w-0">
+									<div className="text-xs font-medium truncate">{activity.title}</div>
+									<div className="text-[11px] text-[var(--md-ref-color-on-surface-variant)] truncate">
+										{activity.description}
+									</div>
+								</div>
+								<Button
+									size="small"
+									variant="tonal"
+									disabled={isProcessing}
+									onClick={() => handleBreakSuggestionSelect(activity.id)}
+									className="text-[11px]"
+								>
+									採用
+								</Button>
+							</div>
+						))}
+					</div>
+				</div>
+			)}
 
 			{/* Row 2: Action Buttons */}
 			<div className="flex gap-2 justify-end">


### PR DESCRIPTION
## Summary\n- add editable break activity catalog utility with pinning, feedback, and rotation\n- render break activity suggestion cards in action notification UI\n- add settings section to edit, pin, and enable/disable break activities\n- include break minute context in timer notification messages for bucketed ranking\n\n## Testing\n- npm run -s test -- src/utils/break-activity-catalog.test.ts\n- npm run -s type-check\n- npm run -s check\n\nCloses #226

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 休憩時間中に推奨されるアクティビティが通知に表示されるようになりました
  * 設定画面で休憩アクティビティカタログを管理できるようになりました（追加、編集、固定化、有効/無効の切り替え）
  * 推奨されるアクティビティは休憩時間と疲労度に基づいてパーソナライズされます
  * ユーザーの選択フィードバックにより、推奨精度が向上します

* **テスト**
  * 休憩アクティビティカタログの機能テストを追加しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->