### PR TITLE
[Impl] [Idea][Notify] Snooze debt tracking and repayment

### DIFF
--- a/docs/plans/2026-02-15-issue-227-break-debt-design.md
+++ b/docs/plans/2026-02-15-issue-227-break-debt-design.md
@@ -1,0 +1,65 @@
+# Issue #227 Break Debt Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** スヌーズ/スキップされた休憩を break debt として記録し、次回以降の休憩に返済分を上乗せしつつ、UI に残高を表示する。
+
+**Architecture:** フロントエンドに小さな `break-debt-policy` ユーティリティを追加し、ActionNotification の操作イベント（skip/extend）で負債を加算、休憩通知表示時に返済を計算して残高を更新する。永続化は `localStorage` を使い、返済上限は `maxBreakMinutes` でクランプする。
+
+**Tech Stack:** TypeScript, Vitest, React (ActionNotificationView)
+
+---
+
+### Task 1: Break Debt モデルを TDD で追加
+
+**Files:**
+- Create: `src/utils/break-debt-policy.ts`
+- Test: `src/utils/break-debt-policy.test.ts`
+
+**Step 1: Write failing tests**
+- debt 加算（skip/snooze）
+- 次回休憩で返済（上限 cap を超えない）
+- 準拠サイクルで debt 減衰
+- localStorage 永続化ロード/セーブ
+
+**Step 2: Run tests to verify failures**
+- `pnpm vitest run src/utils/break-debt-policy.test.ts`
+
+**Step 3: Implement minimal policy**
+- `accrueBreakDebt`
+- `applyBreakRepayment`
+- `decayBreakDebt`
+- `loadBreakDebtState` / `saveBreakDebtState`
+
+**Step 4: Run tests to verify pass**
+- `pnpm vitest run src/utils/break-debt-policy.test.ts`
+
+### Task 2: ActionNotificationView へ統合
+
+**Files:**
+- Modify: `src/views/ActionNotificationView.tsx`
+
+**Step 1: Integrate debt read/repay on break notification render**
+- 休憩通知表示時に返済候補を計算
+- 返済後の debt を保存
+- 表示 break 分に repayment を反映
+
+**Step 2: Integrate debt accrual on skip/extend for break deferral**
+- `skip` または break 通知上の `extend` 実行時に debt 加算
+
+**Step 3: Show debt balance in UI**
+- ActionNotificationView に `休憩負債: Xm` を表示
+
+### Task 3: Verification
+
+**Files:**
+- Modify if needed: `src/views/ActionNotificationView.tsx`
+- Test: existing test suite subsets
+
+**Step 1: Run focused tests**
+- `pnpm vitest run src/utils/break-debt-policy.test.ts`
+
+**Step 2: Run project checks required by autopilot**
+- `pnpm run check`
+- `cargo test -p pomodoroom-core`
+- `cargo test -p pomodoroom-cli -- --test-threads=1`

--- a/src/utils/break-debt-policy.test.ts
+++ b/src/utils/break-debt-policy.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import {
+	applyBreakRepayment,
+	accrueBreakDebt,
+	createBreakDebtState,
+	decayBreakDebt,
+	loadBreakDebtState,
+	saveBreakDebtState,
+} from "./break-debt-policy";
+
+describe("break-debt-policy", () => {
+	beforeEach(() => {
+		localStorage.clear();
+	});
+
+	it("accrues debt on skipped/snoozed breaks", () => {
+		const base = createBreakDebtState();
+		const next = accrueBreakDebt(base, { deferredMinutes: 5, reason: "skip" });
+		expect(next.balanceMinutes).toBe(5);
+		expect(next.deferredBreakCount).toBe(1);
+	});
+
+	it("applies repayment without exceeding max break cap", () => {
+		const state = { ...createBreakDebtState(), balanceMinutes: 20 };
+		const repaid = applyBreakRepayment(state, {
+			scheduledBreakMinutes: 15,
+			maxBreakMinutes: 20,
+		});
+
+		expect(repaid.nextBreakMinutes).toBe(20);
+		expect(repaid.repaidMinutes).toBe(5);
+		expect(repaid.state.balanceMinutes).toBe(15);
+	});
+
+	it("decays debt over compliant cycles", () => {
+		const state = { ...createBreakDebtState(), balanceMinutes: 6 };
+		const decayed = decayBreakDebt(state, { compliantCycles: 2, decayMinutesPerCycle: 2 });
+		expect(decayed.balanceMinutes).toBe(2);
+	});
+
+	it("persists and reloads debt state", () => {
+		const state = { ...createBreakDebtState(), balanceMinutes: 9, deferredBreakCount: 3 };
+		saveBreakDebtState(state);
+		const loaded = loadBreakDebtState();
+		expect(loaded.balanceMinutes).toBe(9);
+		expect(loaded.deferredBreakCount).toBe(3);
+	});
+});

--- a/src/utils/break-debt-policy.ts
+++ b/src/utils/break-debt-policy.ts
@@ -1,0 +1,92 @@
+export interface BreakDebtState {
+	balanceMinutes: number;
+	deferredBreakCount: number;
+	updatedAt: string;
+}
+
+export type BreakDebtReason = "skip" | "snooze";
+
+export interface BreakDebtRepaymentResult {
+	nextBreakMinutes: number;
+	repaidMinutes: number;
+	state: BreakDebtState;
+}
+
+const STORAGE_KEY = "pomodoroom-break-debt-v1";
+
+export function createBreakDebtState(): BreakDebtState {
+	return {
+		balanceMinutes: 0,
+		deferredBreakCount: 0,
+		updatedAt: new Date().toISOString(),
+	};
+}
+
+export function loadBreakDebtState(): BreakDebtState {
+	try {
+		const raw = localStorage.getItem(STORAGE_KEY);
+		if (!raw) return createBreakDebtState();
+		const parsed = JSON.parse(raw) as Partial<BreakDebtState>;
+		const balanceMinutes = Math.max(0, Math.floor(Number(parsed.balanceMinutes ?? 0)));
+		const deferredBreakCount = Math.max(0, Math.floor(Number(parsed.deferredBreakCount ?? 0)));
+		const updatedAt =
+			typeof parsed.updatedAt === "string" && parsed.updatedAt.length > 0
+				? parsed.updatedAt
+				: new Date().toISOString();
+		return { balanceMinutes, deferredBreakCount, updatedAt };
+	} catch {
+		return createBreakDebtState();
+	}
+}
+
+export function saveBreakDebtState(state: BreakDebtState): void {
+	localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+}
+
+export function accrueBreakDebt(
+	state: BreakDebtState,
+	input: { deferredMinutes: number; reason: BreakDebtReason },
+): BreakDebtState {
+	const deferred = Math.max(0, Math.floor(input.deferredMinutes));
+	if (deferred <= 0) return state;
+	return {
+		balanceMinutes: state.balanceMinutes + deferred,
+		deferredBreakCount: state.deferredBreakCount + 1,
+		updatedAt: new Date().toISOString(),
+	};
+}
+
+export function applyBreakRepayment(
+	state: BreakDebtState,
+	input: { scheduledBreakMinutes: number; maxBreakMinutes: number },
+): BreakDebtRepaymentResult {
+	const scheduled = Math.max(1, Math.floor(input.scheduledBreakMinutes));
+	const cap = Math.max(scheduled, Math.floor(input.maxBreakMinutes));
+	const availableHeadroom = Math.max(0, cap - scheduled);
+	const repaidMinutes = Math.min(state.balanceMinutes, availableHeadroom);
+	const nextBreakMinutes = scheduled + repaidMinutes;
+	return {
+		nextBreakMinutes,
+		repaidMinutes,
+		state: {
+			balanceMinutes: Math.max(0, state.balanceMinutes - repaidMinutes),
+			deferredBreakCount: state.deferredBreakCount,
+			updatedAt: new Date().toISOString(),
+		},
+	};
+}
+
+export function decayBreakDebt(
+	state: BreakDebtState,
+	input: { compliantCycles: number; decayMinutesPerCycle: number },
+): BreakDebtState {
+	const cycles = Math.max(0, Math.floor(input.compliantCycles));
+	const perCycle = Math.max(0, Math.floor(input.decayMinutesPerCycle));
+	const decay = cycles * perCycle;
+	if (decay <= 0) return state;
+	return {
+		balanceMinutes: Math.max(0, state.balanceMinutes - decay),
+		deferredBreakCount: state.deferredBreakCount,
+		updatedAt: new Date().toISOString(),
+	};
+}


### PR DESCRIPTION
## Linked Issue
Closes #227

## What Changed
- 

## Why
- 

## Test Evidence
- [ ] pnpm run check
- [ ] cargo test -p pomodoroom-core
- [ ] cargo test -p pomodoroom-cli -- --test-threads=1
- [ ] Manual test done

## Screenshots / Logs (if needed)

## Risks
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 休憩をスキップまたは先延ばしする際に「休憩負債」が蓄積される機能を追加しました。
  * UI にはユーザーの現在の休憩負債残高と推奨される休憩時間が表示されるようにしました。
  * 蓄積された負債は次回の休憩で自動的に返済され、規準に従うことで時間とともに減衰します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->