### PR TITLE
fix(schedule): show task start notification even when running task exists

### DIFF
--- a/src/views/ShellView.tsx
+++ b/src/views/ShellView.tsx
@@ -780,12 +780,9 @@ export default function ShellView() {
 		return selectNextBoardTasks(taskStore.tasks, 3);
 	}, [taskStore.tasks]);
 
-	// Ask whether to start when a task reaches scheduled start time (if no running task).
+	// Ask whether to start when a task reaches scheduled start time.
+	// Always show notification regardless of running tasks (per issue #391).
 	useEffect(() => {
-		if (taskStore.getTasksByState('RUNNING').length > 0) {
-			return;
-		}
-
 		const dueTask = selectDueScheduledTask(taskStore.tasks, Date.now());
 		if (!dueTask) return;
 


### PR DESCRIPTION
## Summary
- Remove the condition that skips task start notifications when a running task exists
- Task start notifications now always appear when a task reaches its scheduled start time

## Problem
Task start notifications were only shown when no running task existed. This meant users wouldn't be notified about scheduled tasks if they were already working on something else.

## Solution
Removed the early return check `if (taskStore.getTasksByState('RUNNING').length > 0)` so notifications are always shown when a task reaches its scheduled start time, allowing users to decide whether to switch tasks.

Fixes #391

## Test plan
- [ ] Schedule a task with a specific start time
- [ ] Start another task and wait for the scheduled task's start time
- [ ] Verify notification appears even though a task is running

🤖 Generated with [Claude Code](https://claude.com/claude-code)