### PR TITLE
fix(ui): make summary cards responsive in time views

### DIFF
--- a/src/views/DailyTimeView.tsx
+++ b/src/views/DailyTimeView.tsx
@@ -133,7 +133,7 @@ export default function DailyTimeView() {
 				</div>
 
 				{/* Summary cards */}
-				<div className="grid grid-cols-4 gap-3 mb-6">
+				<div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-6">
 					<div className="px-5 py-4 rounded-xl border border-[var(--md-ref-color-outline-variant)] bg-[var(--md-ref-color-surface-container-low)]">
 						<div className="text-xs font-medium text-[var(--md-ref-color-on-surface-variant)] mb-1">総予定時間</div>
 						<div className="text-3xl font-bold tracking-tight text-[var(--md-ref-color-on-surface)]">{totals.totalEstimated}<span className="text-base font-normal ml-1">分</span></div>

--- a/src/views/MacroTimeView.tsx
+++ b/src/views/MacroTimeView.tsx
@@ -88,7 +88,7 @@ export default function MacroTimeView() {
 				</div>
 
 				{/* Summary cards */}
-				<div className="grid grid-cols-4 gap-3 mb-6">
+				<div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-6">
 					<div className="px-5 py-4 rounded-xl border border-[var(--md-ref-color-outline-variant)] bg-[var(--md-ref-color-surface-container-low)]">
 						<div className="text-xs font-medium text-[var(--md-ref-color-on-surface-variant)] mb-1">総予定時間</div>
 						<div className="text-3xl font-bold tracking-tight text-[var(--md-ref-color-on-surface)]">{totals.totalEstimated}<span className="text-base font-normal ml-1">分</span></div>


### PR DESCRIPTION
## Summary
- Change fixed 4-column grid to responsive `grid-cols-2 md:grid-cols-4` in time view summary cards
- Applies to `MacroTimeView.tsx` and `DailyTimeView.tsx`
- Cards now stack as 2 columns on mobile and expand to 4 columns on medium+ screens

## Test plan
- [x] Visual inspection on different screen widths
- [x] TypeScript compiles without errors

Closes #392

🤖 Generated with [Claude Code](https://claude.com/claude-code)