### PR TITLE
fix(ui): improve side panel layout and task card display

### DIFF
--- a/src/components/m3/AppShell.tsx
+++ b/src/components/m3/AppShell.tsx
@@ -424,7 +424,7 @@ export const AppShell: React.FC<AppShellProps> = ({
 
 					{/* Right side panel (cards inside) */}
 					{rightPanel && (
-						<aside className="w-[360px] shrink-0 overflow-hidden">
+						<aside className="w-[270px] shrink-0 overflow-hidden">
 							{rightPanel}
 						</aside>
 					)}


### PR DESCRIPTION
## Summary
- Reduce side panel width from 360px to 270px (approximately 3/4 of original)
- Show tomorrow tasks as TaskCard components for consistent UI
- Add TaskCard import and use density="compact" for compact display
- Separate task and calendar event display in TOMORROW section

## Test plan
- [x] TypeScript compiles without errors
- [x] Side panel width is now narrower
- [x] Tomorrow tasks display as TaskCard components
- [x] Calendar events still display as list items

Closes #395

🤖 Generated with [Claude Code](https://claude.com/claude-code)