### PR TITLE
fix(ui): change READY state icon to radio_button_unchecked

### DIFF
--- a/src/components/m3/TaskCard.tsx
+++ b/src/components/m3/TaskCard.tsx
@@ -190,7 +190,7 @@ function resolveSections(
 }
 
 function getStatusControlMeta(state: TaskState): {
-	icon: "check_circle" | "radio_button_checked" | "pause" | "check_circle";
+	icon: "radio_button_unchecked" | "radio_button_checked" | "pause" | "check_circle";
 	colorClass: string;
 	action: TaskOperation | null;
 	label?: string;
@@ -198,7 +198,7 @@ function getStatusControlMeta(state: TaskState): {
 	switch (state) {
 		case "READY":
 			return {
-				icon: "check_circle",
+				icon: "radio_button_unchecked",
 				colorClass: "text-[var(--md-ref-color-on-surface-variant)]",
 				action: "start",
 			};


### PR DESCRIPTION
## Summary
- Change READY state icon from `check_circle` to `radio_button_unchecked`
- The `check_circle` icon was confusing as it suggests "completed" or "done"
- `radio_button_unchecked` better represents "ready to start" (未開始) state
- Click action (start) remains functional for starting the task

## Test plan
- [x] TypeScript compiles without errors
- [x] READY tasks now show unchecked radio button icon
- [x] Clicking the icon still triggers start action

Closes #396

🤖 Generated with [Claude Code](https://claude.com/claude-code)