### PR TITLE
fix(ui): prevent layout shift from scrollbar appearing/disappearing

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -645,6 +645,8 @@ html {
   -moz-osx-font-smoothing: grayscale;
   text-rendering: optimizeLegibility;
   background: transparent;
+  /* Prevent layout shift from scrollbar appearing/disappearing */
+  scrollbar-gutter: stable;
 }
 
 html, body, #root {


### PR DESCRIPTION
## Summary
- Add `scrollbar-gutter: stable` to html element
- This reserves space for scrollbar even when not visible
- Prevents content from shifting when scrollbar appears/disappears

## Test plan
- [x] TypeScript compiles without errors
- [x] No layout shift when content grows/shrinks

Closes #399

🤖 Generated with [Claude Code](https://claude.com/claude-code)