### PR TITLE
feat(notification): implement stacked notification dialogs (#402)

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -74,6 +74,7 @@ fn main() {
             window::cmd_get_window_label,
             window::cmd_open_reference,
             window::cmd_open_action_notification,
+            window::cmd_close_action_notification,
             #[cfg(windows)]
             window::cmd_apply_rounded_corners,
             // Bridge commands (CLI core)


### PR DESCRIPTION
## Summary
- Add support for up to 3 simultaneous notification windows
- New notification windows are offset by 30px from previous
- Add notification queue in frontend when max is reached
- Add `cmd_close_action_notification` to track notification lifecycle
- Generate unique labels for each notification window
- Auto-process next queued notification when one is closed

Fixes #402

## Behavior
- Max 3 simultaneous stacked notifications
- Each notification is offset 30px down-right from the previous
- 4th+ notifications are queued and shown when previous ones close
- When a notification is processed (action clicked or dismissed), the next queued notification is shown

## Technical Changes
- **Rust backend** (`src-tauri/src/window.rs`):
  - Track active notifications with `ACTIVE_NOTIFICATIONS` state
  - Calculate offset positions with `calculate_notification_position()`
  - Generate unique UUID-based labels for each notification
  - Add `cmd_close_action_notification` for cleanup
  
- **Frontend** (`src/hooks/useActionNotification.ts`):
  - Add `NOTIFICATION_QUEUE` for notifications when max reached
  - `showActionNotification()` catches max-reached error and queues
  - `onNotificationClosed()` triggers queue processing
  
- **Notification View** (`src/views/ActionNotificationView.tsx`):
  - Call `cmd_close_action_notification` before closing
  - Trigger `onNotificationClosed()` to process next queued notification

## Test plan
- [ ] Trigger first notification → should appear at (20, 20)
- [ ] Trigger second notification → should appear at (50, 50)
- [ ] Trigger third notification → should appear at (80, 80)
- [ ] Trigger fourth notification → should be queued, not shown
- [ ] Close first notification → fourth notification should appear at (20, 20)

🤖 Generated with [Claude Code](https://claude.com/claude-code)